### PR TITLE
Fix Webpack on Windows

### DIFF
--- a/pootle/apps/pootle_app/management/commands/webpack.py
+++ b/pootle/apps/pootle_app/management/commands/webpack.py
@@ -86,11 +86,11 @@ class Command(BaseCommand):
 
         if custom_static_dirs:
             # XXX: review this for css
-            # Append `js/` so that it's not necessary to reference it from the
+            # Append `js` so that it's not necessary to reference it from the
             # `webpack.config.js` file
-            custom_static_dirs = map(lambda x: os.path.join(x, 'js/'),
+            custom_static_dirs = map(lambda x: os.path.join(x, 'js'),
                                      custom_static_dirs)
-            os.environ['WEBPACK_ROOT'] = ':'.join(custom_static_dirs)
+            os.environ['WEBPACK_ROOT'] = ';'.join(custom_static_dirs)
 
         try:
             subprocess.call(webpack_args)

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -68,7 +68,7 @@ var resolve = {
 // and merge the entry definitions from the manifest files
 var root = process.env.WEBPACK_ROOT;
 if (root !== undefined) {
-  var customPaths = root.split(':');
+  var customPaths = root.split(';');
   resolve.root = [path.join(__dirname, 'node_modules')].concat(customPaths);
 
   function mergeWithArrays(target, source) {
@@ -140,7 +140,8 @@ var config = {
   output: {
     path: __dirname,
     publicPath: process.env.WEBPACK_PUBLIC_PATH,
-    filename: './[name]/app.bundle.js'
+    filename: '[name]/app.bundle.js',
+    chunkFilename: '[name]/app.bundle.js'
   },
   module: {
     loaders: [


### PR DESCRIPTION
This makes the build process more Windows-friendly and doesn't result in odd errors like missing 'C:\manifest.json' file caused by incorrect path splitting.

It also prevents Webpack chunks to be created under odd directory names, like `pootle/static/js/11../11/app.bundle.js`. With that change the path is expected to be just `pootle/static/js/11/app.bundle.js` where `11` is a chunk ID (we have a bunch of these).
