### PR TITLE
RawFontTextarea: re-render when switching to raw mode

### DIFF
--- a/pootle/static/js/editor/components/RawFontTextarea.js
+++ b/pootle/static/js/editor/components/RawFontTextarea.js
@@ -83,8 +83,9 @@ const RawFontTextarea = React.createClass({
     // If this implementation ever becomes a measured cause of slowness and the
     // undo/redo stack also grows, consider using immutable data structures.
     return (
-      !_.isEqual(this.state.done, nextState.done) &&
-      !_.isEqual(this.state.undone, nextState.undone)
+      this.isRawMode !== nextProps.isRawMode ||
+      (!_.isEqual(this.state.done, nextState.done) &&
+       !_.isEqual(this.state.undone, nextState.undone))
     );
   },
 


### PR DESCRIPTION
Apparently calling `rawFont.update()` in textareas while being in
`componentWillReceiveProps` isn't enough, so we need to re-render it to ensure
the height re-calculations will kick in when switching modes.
