### PR TITLE
Show 'All Languages' / 'All Projects' in navbar dropdowns

### DIFF
--- a/pootle/static/css/navbar.css
+++ b/pootle/static/css/navbar.css
@@ -244,6 +244,12 @@ html[dir="rtl"] #navbar .select2-container .select2-choice abbr
     max-width: 35vw;
 }
 
+.select2-result.default
+{
+    color: #0489b7;
+    font-style: italic;
+}
+
 #navbar .select2-default
 {
     color: #7fe8f5 !important;

--- a/pootle/static/js/browser.js
+++ b/pootle/static/js/browser.js
@@ -150,6 +150,18 @@ function handleBeforeNavDropDownResourceSelect(e) {
   }
 }
 
+function handleSelectClose(e) {
+  const $select = $(e.target);
+
+  /* The code below may look strange, but this trick
+     makes Select2 properly display the placeholder;
+     otherwise, when selecting an option with an
+     empty value, Select2 will display this option
+     as a regular value, and with regular styling */
+  if ($select.val() === '') {
+    $select.select2('val', '');
+  }
+}
 
 function makeNavDropdown(selector, opts, handleSelectClick, handleBeforeSelect) {
   const defaults = {
@@ -160,12 +172,14 @@ function makeNavDropdown(selector, opts, handleSelectClick, handleBeforeSelect) 
   };
   const options = $.extend({}, defaults, opts);
 
-  return utils.makeSelectableInput(
+  utils.makeSelectableInput(
     selector,
     options,
     handleSelectClick,
     handleBeforeSelect
   );
+
+  $(selector).on('select2-close', (e) => handleSelectClose(e));
 }
 
 

--- a/pootle/static/js/common.js
+++ b/pootle/static/js/common.js
@@ -167,7 +167,7 @@ PTL.common = {
     });
 
     /* Sorts language names within select elements */
-    const ids = ['id_languages', 'id_alt_src_langs', '-language',
+    const ids = ['id_languages', 'id_alt_src_langs',
                  '-source_language'];
 
     $.each(ids, (i, id) => {

--- a/pootle/templates/core/_breadcrumbs.html
+++ b/pootle/templates/core/_breadcrumbs.html
@@ -13,6 +13,8 @@
     style="visibility: hidden;">
     {% if has_admin_access or page != "translate" %}
     <option value=""></option>
+    <option value="" class="default">{% trans "All Languages" %}</option>
+    <option disabled></option>
     {% endif %}
     {% for lang_code, lang_name in ALL_LANGUAGES.items %}
     <option value="{{ lang_code }}">{{ lang_name }}</option>
@@ -24,11 +26,12 @@
   <select id="js-select-project" data-initial-code="{{ project.code }}"
     style="visibility: hidden;">
     <option value=""></option>
+    <option value="" class="default">{%  trans "All Projects" %}</option>
+    <option disabled></option>
     {% for proj_code, proj in ALL_PROJECTS.items %}
     <option
       value="{{ proj_code }}"
-      data-state="{{ proj.disabled|yesno:'disabled,enabled' }}">
-      {{ proj.fullname }}
+      data-state="{{ proj.disabled|yesno:'disabled,enabled' }}">{{ proj.fullname }}
     </option>
     {% endfor %}
   </select>


### PR DESCRIPTION
This makes resetting the language or project filter more explicit and easy