### PR TITLE
Modals: simplify triggering code

### DIFF
--- a/pootle/static/js/shared/components/KeyboardHelpDialog.js
+++ b/pootle/static/js/shared/components/KeyboardHelpDialog.js
@@ -11,14 +11,8 @@ import { showModal } from './Modal';
 
 import './KeyboardHelpDialog.css';
 
-let keyboardHelpOpen = false;
 
 export function showKeyboardHelpDialog() {
-  if (keyboardHelpOpen) {
-    return;
-  }
-
-  keyboardHelpOpen = true;
   showModal({
     title:
       <span>
@@ -27,9 +21,9 @@ export function showKeyboardHelpDialog() {
       </span>,
     children: <HelpDialogContent />,
     className: 'KeyboardHelpDialog',
-    onClose: () => { keyboardHelpOpen = false; },
   });
 }
+
 
 const HelpDialogContent = React.createClass({
 

--- a/pootle/static/js/shared/components/Modal.js
+++ b/pootle/static/js/shared/components/Modal.js
@@ -21,13 +21,10 @@ export function showModal(props) {
   return ReactDOM.render(
     <Modal
       {...props}
-      onClose={ () => {
+      onClose={() => {
         ReactDOM.unmountComponentAtNode(div);
         document.body.removeChild(div);
-        if ('onClose' in props) {
-          props.onClose();
-        }
-      } }
+      }}
     />,
     div
   );


### PR DESCRIPTION
~~On the one hand, using a fixed node for mounting modals is enough, as there will
be a single modal being displayed at a time (at least from imperative code).~~

Also, adding extra flags to avoid re-rendering a modal adds extra code for no
practical purpose. If imperatively opening modals ever becomes a measured
bottleneck, the `Modal` component can easily be converted into a
`PureComponent`. Note how at the top-level of a rendering tree, the same rules
apply as anywhere else in the tree.