### PR TITLE
Cleanup: no need to order on full name

### DIFF
--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -216,7 +216,7 @@ class Language(models.Model, TreeItem):
             user, select_related=select_related
         ).select_related(
             "project"
-        ).order_by('project__fullname')
+        )
 
     def get_announcement(self, user=None):
         """Return the related announcement, if any."""


### PR DESCRIPTION
With the new browsing table, this is now purely a client-side concern, which
will determine how to best display data.