### PR TITLE
Factor out path-based view dispatching

### DIFF
--- a/pootle/apps/pootle_statistics/forms.py
+++ b/pootle/apps/pootle_statistics/forms.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-"""Form fields required for handling translation files."""
-
 from django import forms
 
+from pootle.core.forms import PathForm
 
-class StatsForm(forms.Form):
+
+class StatsForm(PathForm):
 
     offset = forms.IntegerField(required=False)
-    path = forms.CharField(max_length=2048, required=True)
 
-    def clean_path(self):
-        return self.cleaned_data.get("path", "/") or "/"
+    def clean_offset(self):
+        return self.cleaned_data.get('offset', 0)

--- a/pootle/apps/pootle_statistics/urls.py
+++ b/pootle/apps/pootle_statistics/urls.py
@@ -14,6 +14,6 @@ from . import views
 urlpatterns = [
     # XHR
     url(r'^xhr/stats/contributors/?$',
-        views.TopContributorsJSON.as_view(),
+        views.TopContributorsPathDispatcherView.as_view(),
         name='pootle-xhr-contributors'),
 ]

--- a/pootle/core/forms.py
+++ b/pootle/core/forms.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -151,3 +152,12 @@ class MathCaptchaForm(forms.Form):
         else:
             self.reset_captcha()
         return super(MathCaptchaForm, self).clean()
+
+
+class PathForm(forms.Form):
+    """Form used for validating GET queryset parameters in a dispatcher view."""
+
+    path = forms.CharField(max_length=2048, required=True)
+
+    def clean_path(self):
+        return self.cleaned_data.get('path', '/')

--- a/pootle/core/views/__init__.py
+++ b/pootle/core/views/__init__.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -11,15 +12,15 @@ from django.views.defaults import (permission_denied as django_403,
                                    server_error as django_500)
 
 from .api import APIView
-from .base import PootleAdminView, PootleJSON
+from .base import BasePathDispatcherView, PootleAdminView, PootleJSON
 from .browse import PootleBrowseView
 from .export import PootleExportView
 from .translate import PootleTranslateView
 
 
 __all__ = (
-    'APIView', 'PootleJSON', 'PootleAdminView', 'PootleBrowseView',
-    'PootleExportView', 'PootleTranslateView',
+    'APIView', 'BasePathDispatcherView', 'PootleJSON', 'PootleAdminView',
+    'PootleBrowseView', 'PootleExportView', 'PootleTranslateView',
 )
 
 


### PR DESCRIPTION
By factoring out the querystring's path-based view dispatching, we will be able
to reuse it other internal API endpoints too.

These changes generalize how a view accepting a `path` GET parameter can
delegate to other views. Views inheriting from the new `BasePathDispatcherView`
need to declaratively provide the collection of view classes that will be
instantiated and dispatched based on the type of path passed:

  * `store_view_class` for paths matching a store
  * `directory_view_class` for paths matching a directory
  * `language_view_class` for paths matching a language
  * `project_view_class` for paths matching an individual project
  * `xlanguage_view_class` for paths matching a project resource across
    languages

Likewise, all the path parts (language code, project code, directory path and
filename) will be passed individually to the dispatched views, as well as the
cleaned query string data (provided they are part of `form_class`).