### PR TITLE
MarkupField: implement `to_python`

### DIFF
--- a/pootle/core/markup/fields.py
+++ b/pootle/core/markup/fields.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -112,6 +113,9 @@ class MarkupField(models.TextField):
             return value.raw
 
         return value
+
+    def to_python(self, value):
+        return self.get_prep_value(value)
 
     def value_to_string(self, obj):
         value = self.value_from_object(obj)


### PR DESCRIPTION
This fixes an ugly bug when creating and updating static pages' content.

It turns out that Django 1.9 silently introduced a backwards-incompatible change
which implemented `TextField`'s `to_python` method, and forcing coercion to text
there.

Since `MarkupField` subclasses `TextField` but didn't implement `to_python`
(rather `get_prep_value`), `TextField`'s `to_python` was being called when
cleaning the form data, hence coercing the `MarkupField` instance to a string
via its `__unicode__` method, which in turn returns the HTML-rendered version of
the raw text.

Since we want to get the raw text, we need to ensure `to_python` does the same
as before, i.e. use `get_prep_value`'s code.

Refs. https://code.djangoproject.com/ticket/24677