### PR TITLE
Editor: remove the ability to jump to units by index

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Zing Changelog
 v0.1.1 (in development)
 -----------------------
 
+* Editor changes:
+  * Removed the ability to jump to units by index (#79).
+
 
 v0.1.0 (2016-11-09)
 -------------------

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -109,32 +109,6 @@ html[dir="rtl"] #toolbar > div:last-child
     top: 2px;
 }
 
-#prevnext #item-number
-{
-    margin: 0 -0.3em;
-    padding: 0 0.3em;
-    text-align: center;
-    position: relative;
-    border: 1px solid transparent;
-    background: transparent;
-    display: inline-block;
-    max-width: 5em;
-    white-space: nowrap;
-    outline: 0;
-}
-
-#prevnext:hover #item-number,
-#prevnext:focus #item-number
-{
-    background: #fff;
-    border: 1px solid #d9d9d9;
-}
-
-#prevnext #items-count
-{
-    display: inline-block;
-}
-
 
 /* EDITOR - GENERAL */
 

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -187,8 +187,6 @@ PTL.editor = {
      */
 
     /* Editor toolbar navigation/search/filtering */
-    $('#toolbar').on('keypress', '.js-unit-index', (e) => this.gotoIndex(e));
-    $('#toolbar').on('dblclick click', '.js-unit-index', (e) => this.unitIndex(e));
     $('#toolbar').on('click', '#js-nav-prev', () => this.gotoPrev());
     $('#toolbar').on('click', '#js-nav-next', () => this.gotoNext());
     $('#toolbar').on('change', '#js-filter-sort', () => this.filterSort());
@@ -1728,52 +1726,6 @@ PTL.editor = {
       PTL.editor.setOffset(uid);
     }
     return true;
-  },
-
-  /* Selects the element's contents and sets the focus */
-  unitIndex(e) {
-    e.preventDefault();
-
-    const selection = window.getSelection();
-    const range = document.createRange();
-
-    range.selectNodeContents(this.unitIndexEl);
-    selection.removeAllRanges();
-    selection.addRange(range);
-    this.unitIndexEl.focus();
-  },
-
-  /* Loads the editor on a index */
-  gotoIndex(e) {
-    if (e.which !== 13) { // Enter key
-      return;
-    }
-
-    e.preventDefault();
-
-    let index = parseInt(this.unitIndexEl.textContent, 10);
-    if (isNaN(index)) {
-      return;
-    }
-    index = Math.max(0, index - 1);
-    if (index >= 0 && index <= this.units.total) {
-      // if index is outside of current uids clear units first
-      if (index < this.initialOffset || index >= this.getOffsetOfLastUnit()) {
-        this.initialOffset = -1;
-        this.offset = 0;
-        this.offsetRequested = index + 1;
-        $.history.load(utils.updateHashPart('offset',
-                                            this.getStartOfChunk(index),
-                                            ['unit']));
-      } else {
-        const uId = this.units.uIds[(index - this.initialOffset)];
-        const newHash = utils.updateHashPart('unit', uId);
-        $.history.load(utils.updateHashPart('offset',
-                                            this.getStartOfChunk(index),
-                                            [],
-                                            newHash));
-      }
-    }
   },
 
   /*

--- a/pootle/templates/editor/_toolbar.html
+++ b/pootle/templates/editor/_toolbar.html
@@ -13,8 +13,8 @@
     <button id="js-nav-prev" class="btn btn-xs"
       title="{% trans 'Go to the previous string (Ctrl+Up)' %}">▲</button>
     <span id="item-navigation">
-      <span contenteditable id="item-number" class="js-unit-index"
-        title="{% trans 'Current string number (Ctrl+Shift+U)<br/><br/>Type in the number and press Enter<br/>to go to any position' %}">0</span>
+      <span id="item-number" class="js-unit-index"
+        title="{% trans 'Current string number' %}">0</span>
       /
       <span id="items-count" class="js-unit-count" title="{% trans 'Total strings' %}">0</span>
     </span>


### PR DESCRIPTION
The feature is hardly used/useful and adds unnecessary complexity.