### PR TITLE
Cleanup: remove support for amaGama TM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ v0.1.2 (in development)
 * Editor:
   * Added the ability to select groups of failing checks (#80).
   * Multiple UI tweaks, making better use of the available space.
+  * Removed support for the amaGama TM, as the built-in TM suffices (#92).
 * Fixed table sorting for last updated columns (#91).
 * Removed extra layer of serialization (#88).
 

--- a/docs/features/translation_memory.rst
+++ b/docs/features/translation_memory.rst
@@ -31,26 +31,10 @@ Configuring Translation Memory
 ------------------------------
 
 Translation Memory will work out of the box with a default Pootle installation.
-There are three methods of getting Translation Memory.
+There are two methods of getting Translation Memory.
 
-1. Amagama - for remote Translation Memory
-2. Elasticsearch - for local Translation Memory
-3. Elasticsearch - for external Translation Memory
-
-
-.. _translation_memory#amagama:
-
-Amagama based remote TM
-~~~~~~~~~~~~~~~~~~~~~~~
-
-By default Pootle will query Translate's `Amagama
-<http://amagama.translatehouse.org>`_ Translation Memory server, which hosts
-translations of an extensive collection of Opensource software.
-
-If you want to setup and connect to your own TM server then the
-:setting:`AMAGAMA_URL` will allow you to point to a private TM server.
-
-To disable Amagama set :setting:`AMAGAMA_URL` to ``''``.
+1. Elasticsearch - for local Translation Memory
+2. Elasticsearch - for external Translation Memory
 
 
 .. _translation_memory#elasticsearch_based_tms:
@@ -87,9 +71,6 @@ uncommenting the example.
 
 Please see the :setting:`POOTLE_TM_SERVER-WEIGHT` for a full example of the
 configuration necessary to set up local/external TM.
-
-Both Amagama and Elasticsearch based TMs can operate together.  Though you may
-want to disable Amagama.
 
 
 .. _translation_memory#local_translation_memory:

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -292,18 +292,6 @@ Configuration settings for applications used by Pootle.
 
 Translation environment configuration settings.
 
-.. setting:: AMAGAMA_URL
-
-``AMAGAMA_URL``
-  Default: ``https://amagama-live.translatehouse.org/api/v1/``
-
-  URL to an amaGama Translation Memory server. The default service should work
-  fine, but if you have a custom server set it here.
-
-  This URL must point to the public API URL which returns JSON. Don't forget
-  the trailing slash.
-
-
 .. setting:: POOTLE_SYNC_FILE_MODE
 
 ``POOTLE_SYNC_FILE_MODE``

--- a/pootle/core/views/translate.py
+++ b/pootle/core/views/translate.py
@@ -26,16 +26,16 @@ class PootleTranslateView(PootleDetailView):
 
     def get_context_data(self, *args, **kwargs):
         ctx = super(PootleTranslateView, self).get_context_data(*args, **kwargs)
-        ctx.update(
-            {'page': 'translate',
-             'ctx_path': self.ctx_path,
-             'check_categories': get_qualitycheck_schema(),
-             'cantranslate': check_permission("translate", self.request),
-             'cansuggest': check_permission("suggest", self.request),
-             'canreview': check_permission("review", self.request),
-             'search_form': make_search_form(request=self.request),
-             'previous_url': get_previous_url(self.request),
-             'POOTLE_MT_BACKENDS': settings.POOTLE_MT_BACKENDS,
-             'AMAGAMA_URL': settings.AMAGAMA_URL,
-             'editor_extends': self.template_extends})
+        ctx.update({
+            'page': 'translate',
+            'ctx_path': self.ctx_path,
+            'check_categories': get_qualitycheck_schema(),
+            'cantranslate': check_permission("translate", self.request),
+            'cansuggest': check_permission("suggest", self.request),
+            'canreview': check_permission("review", self.request),
+            'search_form': make_search_form(request=self.request),
+            'previous_url': get_previous_url(self.request),
+            'POOTLE_MT_BACKENDS': settings.POOTLE_MT_BACKENDS,
+            'editor_extends': self.template_extends,
+        })
         return ctx

--- a/pootle/settings/60-translation.conf
+++ b/pootle/settings/60-translation.conf
@@ -44,13 +44,6 @@ POOTLE_MT_BACKENDS = [
 #    ('YANDEX_TRANSLATE', ''),
 ]
 
-# URL used for the amaGama TM server.
-# The global amaGama service should work fine, but if your language/project
-# has a better server, or you want to use your own, you can edit this setting.
-# This URL must point to the public API URL which returns JSON. Don't forget
-# the trailing slash.
-AMAGAMA_URL = 'https://amagama-live.translatehouse.org/api/v1/'
-
 # See 90-local.conf.template for example configuration for local TM server
 POOTLE_TM_SERVER = {}
 

--- a/pootle/settings/90-dev-local.conf.sample
+++ b/pootle/settings/90-dev-local.conf.sample
@@ -184,9 +184,6 @@ POOTLE_MT_BACKENDS = [
 #        ('YANDEX_TRANSLATE', ''),
 ]
 
-# URL for the amaGama TM server.
-AMAGAMA_URL = 'https://amagama-live.translatehouse.org/api/v1/'
-
 # Silence the DEBUG check on dev servers
 SILENCED_SYSTEM_CHECKS = [
     'pootle.W004',  # python-levenstein not installed

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -95,7 +95,6 @@ DATABASES = {
 
 # Setup for connection to the ElasticSearch server for translation memory based
 # on the projects hosted on Pootle.
-# You may want to set AMAGAMA_URL to '' (empty string) if using this service.
 #
 #POOTLE_TM_SERVER = {
 #    'local': {

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -34,7 +34,6 @@ import UnitAPI from 'api/UnitAPI';
 import cookie from 'utils/cookie';
 import diff from 'utils/diff';
 import { q, qAll } from 'utils/dom';
-import fetch from 'utils/fetch';
 import linkHashtags from 'utils/linkHashtags';
 
 import SuggestionFeedbackForm from './components/SuggestionFeedbackForm';
@@ -575,10 +574,6 @@ PTL.editor = {
 
     if (this.filter === 'search') {
       this.hlSearch();
-    }
-
-    if (this.settings.tmUrl !== '') {
-      this.getTMUnits();
     }
 
     if (this.tmData !== null) {
@@ -2146,55 +2141,6 @@ PTL.editor = {
 
     return '';
   },
-
-  /* Gets TM suggestions from amaGama */
-  getTMUnits() {
-    const unit = this.units.getCurrent();
-    const store = unit.get('store');
-    const src = store.get('source_lang');
-    const tgt = store.get('target_lang');
-    const sText = unit.get('source')[0];
-
-    if (!sText.length || src === tgt) {
-      return;
-    }
-
-    const pStyle = store.get('project_style');
-    let tmUrl = `${this.settings.tmUrl}${src}/${tgt}/unit/` +
-      `?source=${encodeURIComponent(sText)}`;
-
-    if (pStyle.length && pStyle !== 'standard') {
-      tmUrl += `&style=${pStyle}`;
-    }
-
-    fetch({ url: tmUrl, crossDomain: true })
-      .then(
-        (data) => this.handleTmResults(data, store, unit),
-        // eslint-disable-next-line no-console
-        (xhr, s) => console.error(`HTTP ${xhr.status} (${s}): ${tmUrl}`)
-      );
-  },
-
-  handleTmResults(data, store, unit) {
-    if (!data.length) {
-      return false;
-    }
-
-    const sourceText = unit.get('source')[0];
-    const filtered = PTL.editor.filterTMResults(data, sourceText);
-    const name = gettext('Similar translations');
-    const tm = PTL.editor.tmpl.tm({
-      name,
-      store: store.toJSON(),
-      unit: unit.toJSON(),
-      suggs: filtered,
-    });
-
-    $(tm).hide().appendTo('#extras-container')
-                .slideDown(1000, 'easeOutQuad');
-    return true;
-  },
-
 
   /* Rejects a suggestion */
   handleRejectSuggestion(suggId, { requestData = {} } = {}) {

--- a/pootle/templates/editor/_scripts.html
+++ b/pootle/templates/editor/_scripts.html
@@ -17,7 +17,6 @@
 <script type="text/javascript">
 $(function() {
   var options = {
-    tmUrl: '{{ AMAGAMA_URL }}',
     pootlePath: '{{ pootle_path }}',
     ctxPath: '{{ ctx_path }}',
     resourcePath: '{{ resource_path }}',

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -44,7 +44,6 @@ def _test_translate_view(language, request, response, kwargs, settings):
             canreview=check_permission("review", request),
             search_form=make_search_form(request=request),
             POOTLE_MT_BACKENDS=settings.POOTLE_MT_BACKENDS,
-            AMAGAMA_URL=settings.AMAGAMA_URL,
         )
     )
 

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -57,7 +57,6 @@ def _test_translate_view(project, request, response, kwargs, settings):
             canreview=check_permission("review", request),
             search_form=make_search_form(request=request),
             POOTLE_MT_BACKENDS=settings.POOTLE_MT_BACKENDS,
-            AMAGAMA_URL=settings.AMAGAMA_URL,
         )
     )
 
@@ -140,7 +139,6 @@ def test_view_projects_translate(client, settings, request_users):
         canreview=check_permission("review", request),
         search_form=make_search_form(request=request),
         POOTLE_MT_BACKENDS=settings.POOTLE_MT_BACKENDS,
-        AMAGAMA_URL=settings.AMAGAMA_URL,
     )
     view_context_test(ctx, **assertions)
 

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -47,7 +47,7 @@ def _test_translate_view(tp, request, response, kwargs, settings):
         canreview=check_permission("review", request),
         search_form=make_search_form(request=request),
         POOTLE_MT_BACKENDS=settings.POOTLE_MT_BACKENDS,
-        AMAGAMA_URL=settings.AMAGAMA_URL)
+    )
     view_context_test(ctx, **assertions)
 
 


### PR DESCRIPTION
The built-in ES-based TM suffices for Zing's needs.