### PR TITLE
Editor: rework UI for displaying obsoleted units

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ v0.1.2 (in development)
   * Navigating between units now preserves the editor's vertical position.
   * New easy way to preview context rows by just hovering over the unit link.
   * Added the ability to select groups of failing checks (#80).
+  * Tweaked the UI for displaying obsolete messages (#94).
   * Multiple UI tweaks, making better use of the available space.
   * Removed support for the amaGama TM, as the built-in TM suffices (#92).
 * Fixed table sorting for last updated columns (#91).

--- a/pootle/static/css/editor.css
+++ b/pootle/static/css/editor.css
@@ -971,6 +971,7 @@ html[dir="rtl"] .extra-item-block .suggestion-feedback .buttons button
     position: relative;
 }
 
+.translate-full .unit-locked-lightbox,
 .translate-full .translate-lightbox
 {
     background: rgba(0, 0, 0, 0.2);
@@ -978,14 +979,42 @@ html[dir="rtl"] .extra-item-block .suggestion-feedback .buttons button
     z-index: 2;
     margin: -5px;
     box-sizing: border-box;
-    border-radius: 5px;
-    left: 10px;
-    right: 10px;
+    left: 5px;
+    right: 5px;
     top: 5px;
     bottom: 5px;
     display: none;
 }
 
+.translate-full.unit-locked .unit-locked-lightbox,
+.translate-full.suggestion-expanded .translate-lightbox
+{
+    display: block;
+}
+
+.translate-full .unit-locked-lightbox
+{
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.translate-full .unit-locked-lightbox > div
+{
+    display: block;
+    position: relative;
+    height: 100%;
+}
+
+.translate-full .unit-locked-lightbox > div > div
+{
+    position: relative;
+    top: 8.5em;
+    color: #ffb2b0;
+    font-style: italic;
+    font-size: 110%;
+    text-align: center;
+}
+
+.translate-full.unit-locked .unit-locked-lightbox,
 .translate-full.suggestion-expanded .translate-lightbox
 {
     display: block;

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -121,7 +121,6 @@ PTL.editor = {
     this.$filterChecks = $('#js-filter-checks');
     this.$filterChecksWrapper = $('.js-filter-checks-wrapper');
     this.$filterSortBy = $('#js-filter-sort');
-    this.$msgOverlay = $('#js-editor-msg-overlay');
     this.$navNext = $('#js-nav-next');
     this.$navPrev = $('#js-nav-prev');
     this.unitPositionEl = q('.js-unit-position');
@@ -222,12 +221,6 @@ PTL.editor = {
       $(e.target).closest('.js-editor-area-wrapper').removeClass('is-focused');
     });
 
-    /* General */
-    $('#editor').on('click', '.js-editor-reload', (e) => {
-      e.preventDefault();
-      $.history.load('');
-    });
-
     /* Write TM results, special chars... into the currently focused element */
     $('#editor').on('click', '.js-editor-copytext', (e) => this.copyText(e));
     $('#editor').on('click', '.js-editor-copy-tm-text', (e) => this.copyTMText(e));
@@ -293,8 +286,6 @@ PTL.editor = {
     $('#editor').on('click', '.js-comment-remove', (e) => this.removeComment(e));
 
     /* Misc */
-    $(document).on('click', '.js-editor-msg-hide', () => this.hideMsg());
-
     $('#editor').on('click', '.js-toggle-raw', (e) => {
       e.preventDefault();
       $('.js-translate-translation').toggleClass('raw');
@@ -985,27 +976,11 @@ PTL.editor = {
    */
 
   showActivity() {
-    this.hideMsg();
     this.$editorActivity.spin().fadeIn(300);
   },
 
   hideActivity() {
     this.$editorActivity.spin(false).fadeOut(300);
-  },
-
-  /* Displays an informative message */
-  displayMsg({ showClose = true, body = null }) {
-    this.hideActivity();
-    helpers.fixSidebarHeight();
-    this.$msgOverlay.html(
-      this.tmpl.msg({ showClose, body })
-    ).fadeIn(300);
-  },
-
-  hideMsg() {
-    if (this.$msgOverlay.length) {
-      this.$msgOverlay.fadeOut(300);
-    }
   },
 
   /* Displays error messages on top of the toolbar */
@@ -1040,23 +1015,18 @@ PTL.editor = {
     PTL.editor.displayError(text);
   },
 
-  displayObsoleteMsg() {
-    const msgText = t('This string no longer exists.');
-    const backMsg = t('Go back to browsing');
-    const backLink = this.backToBrowserEl.getAttribute('href');
-    const reloadMsg = t('Reload page');
-    const html = [
-      '<div>', msgText, '</div>',
-      '<div class="editor-msg-btns">',
-      '<a class="btn btn-xs js-editor-reload" href="#">', reloadMsg, '</a>',
-      '<a class="btn btn-xs" href="', backLink, '">', backMsg, '</a>',
+  lockEditor(message) {
+    const editorBody = q('.js-editor-cell');
+    editorBody.classList.add('unit-locked');
 
-      '</div>',
-    ].join('');
-
-    this.displayMsg({ body: html, showClose: false });
+    q('.js-unit-locked-message').textContent = message;
+    q('.js-editor-area-wrapper').classList.add('is-disabled');
+    q('.js-translation-area').setAttribute('disabled', 'disabled');
   },
 
+  displayObsoleteMsg() {
+    this.lockEditor(t('This string no longer exists.'));
+  },
 
   /*
    * Misc functions
@@ -1221,7 +1191,6 @@ PTL.editor = {
     this.$viewRowsAfter.addClass('context-mode');
     this.$contextRowsAfter.addClass('context-mode');
   },
-
 
   /* hides the context rows */
   hideContextRows() {

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -3,6 +3,9 @@
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 {% cache settings.POOTLE_CACHE_TIMEOUT unit_edit unit.id unit.mtime cantranslate cansuggest canreview altsrcs user.id LANGUAGE_CODE unit.get_terminology %}
 <td colspan="2" rowspan="1" class="js-editor-cell translate-full translate-focus{% if unit.isfuzzy %} fuzzy-unit{% endif %}" dir="{% locale_dir %}">
+  <div class="unit-locked-lightbox js-unit-locked-lightbox">
+    <div><div class="js-unit-locked-message"></div></div>
+  </div>
   <div class="translate-lightbox js-translate-lightbox"></div>
   <div class="translate-container{% if unit.get_active_critical_qualitychecks.exists %} error{% endif %}">
     <div class="unit-path">


### PR DESCRIPTION
This PR overhauls the UI for displaying obsoleted units: instead of a popup message, an overlay over the editing row is displayed that prevents further action. The PR builds on top of #93.