### PR TITLE
Checks around CDATA sections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Zing Changelog
 v0.1.3 (in development)
 -----------------------
 
+* Improved `tags_differ` check to take into account CDATA sections as if they
+  were tags (#104).
+
 
 v0.1.2 (2016-11-29)
 -------------------

--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -213,7 +213,8 @@ fmt = u'^<(Sync Required|None|no attributes|no tags|' + \
 no_tags_regex = re.compile(fmt, re.U)
 
 fmt = u"<\/?[a-zA-Z_]+.*?>"
-tags_differ_regex_0 = re.compile(u"(%s)" % fmt, re.U)
+cdata_fmt = u'<!\[CDATA\[(?:[^]]|\](?!\]>))*\]\]>'
+tags_differ_regex_0 = re.compile(u"(%s|%s)" % (fmt, cdata_fmt), re.U)
 tags_differ_regex_1 = re.compile(u"<(\/?[a-zA-Z_]+).*?>", re.U)
 
 accelerators_regex_0 = re.compile(u"&(\w+);", re.U)

--- a/tests/misc/checks.py
+++ b/tests/misc/checks.py
@@ -251,8 +251,17 @@ def test_unbalanced_curly_braces(source_string, target_string, should_skip):
 @pytest.mark.parametrize('source_string, target_string, should_skip', [
     (u'a', u'A', True),
     (u'<a href="">a</a>', u'<a href="">a</a>', True),
+    (u'<![CDATA[foo]]>', u'<![CDATA[bar]]>', True),
+    (u'<![CDATA[foo[bar]]]>', u'<![CDATA[foo[bar]]]>', True),
+    (u'<![CDATA[<b>foo</b>]]>', u'<![CDATA[<b>foo</b>]]>', True),
+    (u'<a>a</a> <![CDATA[foo]]>', u'<![CDATA[bar]]> <a>b</a> ', True),
+
     (u'<a href="">a</a>', u'<a href="">a<a>', False),
     (u'<a class="a">a</a>', u'<b class="b">a</b>', False),
+
+    (u'<![CDATA[<a>foo</a>]]>', u'<![CDATA[<a>bar]]></a>', False),
+    (u'<a><![CDATA[<b>foo</b>]]></a>', u'<a><![CDATA[<b>foo</b></a>]]>', False),
+    (u'<a><![CDATA[<b>foo</b>]]>', u'<![CDATA[<b>foo</b></a>]]>', False),
 ])
 def test_tags_differ(source_string, target_string, should_skip):
     check = checker.tags_differ


### PR DESCRIPTION
The PR adds CDATA sections to the `tags_differ` check, so that they are considered as a single block/tag.
~~In this PR two new checks are added around `CDATA` sections:~~
~~* `cdata_missing`: to ensure `CDATA` sections in source texts are also present in target texts.~~
~~* `cdata_tags_differ`: to ensure potential (X)HTML tags present in source text's `CDATA` sections are not missing in target texts. This reuses the `tags_differ` check.~~