### PR TITLE
Editor: break apart tags in JS strings (fix #105)

### DIFF
--- a/pootle/core/templatetags/core.py
+++ b/pootle/core/templatetags/core.py
@@ -28,6 +28,19 @@ def to_js(value):
 
 
 @register.filter
+def to_jquery_safe_js(value):
+    """Returns a string which leaves the value readily available for JS
+    consumption; escapes closing tags to avoid '</script> inside JS string'
+    problem; breaks HTML tags into concatenated strings to avoid jQuery `html()`
+    rendering problem (see https://github.com/evernote/zing/issues/105).
+
+    This template tag needs to be removed once the editor is moved into a native
+    React component
+    """
+    return mark_safe(jsonify(value).replace('</', '<\\/').replace('<', '<"+"'))
+
+
+@register.filter
 def docs_url(path_name):
     """Returns the absolute URL to `path_name` in the RTD docs."""
     return get_docs_url(path_name)

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -175,17 +175,17 @@
 
             <script type="text/javascript">
               PTL.reactEditor.init({
-                initialValues: {{ unit_values|to_js }},
+                initialValues: {{ unit_values|to_jquery_safe_js }},
                 isDisabled: {{ form.target_f.field.widget.attrs.disabled|yesno:'true,false' }},
                 currentLocaleCode: '{{ language.code }}',
                 currentLocaleDir: '{{ language.direction }}',
                 unitId: {{ unit.id }},
-                sourceValues: {{ unit.source_f.strings|to_js }},
+                sourceValues: {{ unit.source_f.strings|to_jquery_safe_js }},
                 sourceLocaleCode: '{{ source_language.code }}',
                 sourceLocaleDir: '{{ source_language.direction }}',
                 hasPlurals: {{ has_plurals|yesno:'true,false' }},
                 targetNplurals: {{ target_nplurals }},
-                alternativeSources: {{ altsrcs|to_js }},
+                alternativeSources: {{ altsrcs|to_jquery_safe_js }},
                 fileType: '{{ filetype }}',
               });
             </script>


### PR DESCRIPTION
See extensive description in #105 for more information.

Note that `to_js` needs to be changed to `to_jquery_safe_js` in override template as well.