### PR TITLE
Cleanup: remove unused cache

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -71,11 +71,6 @@ CACHES = {
         'LOCATION': 'redis://127.0.0.1:6379/15',
         'TIMEOUT': None,
     },
-    'exports': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': os.path.join(ROOT_DIR, 'tests', 'exports'),
-        'TIMEOUT': 259200,  # 3 days.
-    },
 }
 
 # Using synchronous mode for testing


### PR DESCRIPTION
The 'exports' cache was there for the now gone import/export functionality.