### PR TITLE
Tests: use fake Redis client

### DIFF
--- a/pytest_pootle/fixtures/site.py
+++ b/pytest_pootle/fixtures/site.py
@@ -77,7 +77,7 @@ def clear_cache():
     """Currently tests only use one cache so this clears all"""
     from django_redis import get_redis_connection
 
-    get_redis_connection('default').flushdb()
+    get_redis_connection('redis').flushdb()
 
 
 @pytest.fixture(scope="session")

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,7 @@
 # Testing
 
 factory_boy>=2.5.2
+fakeredis==0.8.1
 pytest==3.0.2
 pytest-catchlog==1.2.2
 pytest-cov==2.3.1

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -65,11 +65,16 @@ CACHES = {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': 'redis://127.0.0.1:6379/15',
         'TIMEOUT': None,
+        # FIXME: can't use `fakeredis` here as django-redis' `incr` uses Redis'
+        # `eval()` command, which is unsupported in `fakeredis`.
     },
     'stats': {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': 'redis://127.0.0.1:6379/15',
         'TIMEOUT': None,
+        'OPTIONS': {
+            'REDIS_CLIENT_CLASS': 'fakeredis.FakeStrictRedis',
+        },
     },
 }
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -57,9 +58,7 @@ CACHES = {
     # Must set up entries for persistent stores here because we have a check in
     # place that will abort everything otherwise
     'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': 'redis://127.0.0.1:6379/15',
-        'TIMEOUT': None,
+        'BACKEND': 'pootle.core.cache.DummyCache',
     },
     'redis': {
         'BACKEND': 'django_redis.cache.RedisCache',


### PR DESCRIPTION
This almost entirely removes the dependency on a Redis server for testing.
Unfortunately `fakeredis` cannot be used for the 'redis' named cache (used for
revisions), as django-redis' `incr` implementation uses Redis' `eval()` command,
which is unsupported in `fakeredis` for the time being.

The situation might change when django-redis moves away from using `eval()` or
`fakeredis` provides support for `eval()`.

Update: the `'default'` cache requires no cache at all, so moved that to a dummy backend.