### PR TITLE
Tests: implement snapshot testing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ v0.1.4 (in development)
 * Fixed browser table sorting for total/untranslated columns (#120).
 * Quality checks now default to a site-wide checker (#119). In the future,
   project-specific checkers will be disallowed.
+* Implemented view testing via snapshots (#45). More tests will need to be
+  adapted although this puts in place the scaffolding to write tests using
+  this technique.
 * Removed unused config utilities (#114).
 * Removed unmaintained web-based terminology management (#123).
 

--- a/pootle/core/models/snapshot.py
+++ b/pootle/core/models/snapshot.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Zing contributors.
+#
+# This file is a part of the Zing project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import os
+
+from django.test.utils import ContextList
+from django.utils.functional import cached_property
+
+from pootle.core.utils.json import jsonify
+from pootle.core.utils.list import flatten
+
+
+# List of keys to filter out from a response context
+BLACKLISTED_KEYS = [
+    # Django template language-specific context
+    'block', 'forloop', 'False', 'True', 'None',
+    # More Django stuff
+    'request', 'perms', 'csrf_token', 'OVEREXTENDS_DIRS',
+    # i18n context
+    'LANGUAGES', 'LANGUAGE_BIDI', 'LANGUAGE_CODE',
+    # Static and settings context
+    'MEDIA_URL', 'STATIC_URL',
+    # Zing context processors
+    'settings', 'custom', 'display_agreement',
+    'ALL_LANGUAGES', 'ALL_PROJECTS', 'SOCIAL_AUTH_PROVIDERS',
+
+    # These context data keys are conflicting because they are auto-added by
+    # Django after saving a model (`auto_now_add=True`), and hence they will
+    # always differ across test runs. Until we find a better solution, we
+    # need to filter them out here.
+    'lastupdated',
+]
+
+
+class Snapshot(object):
+
+    def __init__(self, ctx_name, data_dir=None, generate=False, **kwargs):
+        self.filename = '%s.json' % ctx_name
+        self.data_dir = data_dir or ''
+        self.generate = generate
+
+    @cached_property
+    def filepath(self):
+        base_dir = self.data_dir
+        filepath = os.path.abspath(os.path.join(base_dir, self.filename))
+
+        if os.path.commonprefix([filepath, base_dir]) != base_dir:
+            raise ValueError(
+                'The requested file path is out of the data directory.'
+            )
+        return filepath
+
+    @cached_property
+    def reference(self):
+        try:
+            with open(self.filepath) as reference_file:
+                return reference_file.read()
+        except IOError:
+            return None
+
+    def clean(self, data):
+        """Cleans up `data` before using it as a snapshot reference."""
+        # XXX: maybe we can do something smarter than blacklisting when we
+        # have a `ContextList`?
+        if isinstance(data, dict) or isinstance(data, ContextList):
+            return {
+                key: self.clean(data[key]) for key in data.keys()
+                if key not in BLACKLISTED_KEYS
+            }
+        elif isinstance(data, list):
+            return [self.clean(item) for item in data]
+        return data
+
+    def serialize(self, ctx_data):
+        return jsonify(self.clean(ctx_data), indent=2)
+
+    def save(self, ctx_data):
+        """Saves snapshot reference file to disk."""
+        # Make sure directory exists before saving to file
+        try:
+            os.makedirs(os.path.dirname(self.filepath))
+        except OSError:
+            pass
+
+        with open(self.filepath, 'w') as outfile:
+            outfile.write(ctx_data)
+
+    def assert_matches(self, ctx_data):
+        """Asserts whether `ctx_data` matches the reference snapshot.
+
+        The `ctx` data will be cleaned prior to being stored or compared
+        against any references.
+
+        Implementation detail: the reason why this function asserts and
+        doesn't return a boolean is to have useful diffs upon assertion
+        failures.
+        It would be possible to implement custom pytest assertion classes
+        but that's beyond the simplest implementation :)
+        """
+        ctx_data = self.serialize(ctx_data)
+
+        if self.generate:
+            self.save(ctx_data)
+            return
+
+        if self.reference is None:
+            raise AssertionError(
+                'Snapshot file "%s" does not exist.' % self.filepath
+            )
+
+        assert self.reference == ctx_data
+
+
+class SnapshotStack(object):
+    """Context processor implementing a simple stack of `Snapshot`s.
+
+    >> s = SnapshotStack('/foo/bar/')
+    >> with s.push('foo'):
+    >>    # context is 'foo'
+    >>    with s.push('bar'):
+    >>        # context is 'foo.bar'
+
+    Pushing a list of values will be flattened to individual values when
+    determining the context:
+
+    >> with s.push(['foo', 'bar']):
+    >>    # context is 'foo.bar'
+    """
+
+    def __init__(self, snapshot_kwargs):
+        self.stack = []
+        self.snapshot_kwargs = snapshot_kwargs
+
+    def __enter__(self):
+        return Snapshot(self.ctx_name, **self.snapshot_kwargs)
+
+    def __exit__(self, *args, **kwargs):
+        self.pop()
+
+    @property
+    def ctx_name(self):
+        # Disallow leading forward slashes
+        stack_items = filter(None, [
+            item.replace('/', '', 1) if item.startswith('/') else item
+            for item in flatten(self.stack)
+        ])
+        return ''.join([
+            '%s%s' % (
+                '' if i == 0 or i != 0 and stack_items[i-1].endswith('/') else '.',
+                item
+            )
+            for i, item in enumerate(stack_items)
+        ])
+
+    def push(self, value):
+        self.stack.append(value)
+        return self
+
+    def pop(self):
+        self.stack.pop()
+        return self

--- a/pootle/core/utils/json.py
+++ b/pootle/core/utils/json.py
@@ -31,17 +31,21 @@ class PootleJSONEncoder(DjangoJSONEncoder):
         if isinstance(obj, (Promise, Markup)):
             return force_unicode(obj)
 
-        return super(PootleJSONEncoder, self).default(obj)
+        try:
+            return super(PootleJSONEncoder, self).default(obj)
+        except TypeError:
+            return force_unicode(obj)
 
 
-def jsonify(obj):
+def jsonify(obj, indent=None):
     """Serialize Python `obj` object into a JSON string."""
-    if settings.DEBUG:
+    if settings.DEBUG and indent is None:
         indent = 4
-    else:
-        indent = None
 
-    return json.dumps(obj, indent=indent, cls=PootleJSONEncoder, sort_keys=True)
+    return json.dumps(
+        obj, indent=indent, cls=PootleJSONEncoder, sort_keys=True,
+        separators=(',', ': ')
+    )
 
 
 def remove_empty_from_dict(input):

--- a/pootle/core/utils/list.py
+++ b/pootle/core/utils/list.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Zing contributors.
+#
+# This file is a part of the Zing project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from collections import Iterable
+
+
+def flatten(elements):
+    """Flatten a list of values and/or iterables.
+
+    Source: http://stackoverflow.com/a/2158532/783019
+    """
+    for element in elements:
+        if isinstance(element, Iterable) and not isinstance(element, basestring):
+            for sub in flatten(element):
+                yield sub
+        else:
+            yield element

--- a/pytest_pootle/fixtures/cache.py
+++ b/pytest_pootle/fixtures/cache.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) Pootle contributors.
 # Copyright (C) Zing contributors.
 #
 # This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from .revision import Revision
-from .snapshot import Snapshot
-from .virtualresource import VirtualResource
+import fakeredis
+import pytest
 
 
-__all__ = ('Revision', 'Snapshot', 'VirtualResource')
+@pytest.fixture
+def flush_redis():
+    """Flushes fakeredis' module-level state."""
+    redis_conn = fakeredis.FakeStrictRedis()
+    redis_conn.flushall()

--- a/pytest_pootle/fixtures/snapshot.py
+++ b/pytest_pootle/fixtures/snapshot.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Zing contributors.
+#
+# This file is a part of the Zing project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+
+@pytest.fixture
+def snapshot_stack(tests_dir, should_generate_snapshots):
+    """Context processor providing a stack for snapshots."""
+    from pootle.core.models.snapshot import SnapshotStack
+    snapshot_kwargs = {
+        'data_dir': tests_dir('data/snapshots'),
+        'generate': should_generate_snapshots,
+    }
+    return SnapshotStack(snapshot_kwargs)

--- a/pytest_pootle/plugin.py
+++ b/pytest_pootle/plugin.py
@@ -130,6 +130,12 @@ def django_db_use_migrations(tests_use_migration):
     return tests_use_migration
 
 
+@pytest.fixture
+def test_name(request):
+    """Provides current test function's name as a string."""
+    return request.node.originalname
+
+
 pytest_plugins = tuple(
     _load_fixtures(
         fixtures,

--- a/pytest_pootle/utils.py
+++ b/pytest_pootle/utils.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -175,3 +176,13 @@ def log_test_report(debug_logger, timings):
         "TESTS TOTAL queries: %s",
         total_queries)
     debug_logger.debug("%s\n" % ("=" * 80))
+
+
+def as_dir(name):
+    """Returns `name` as a string usable for snapshot stacks."""
+    return name if name.endswith('/') else '%s/' % name
+
+
+def url_name(url):
+    """Returns `url` as a string usable for snapshot stacks."""
+    return url.replace('/', '_')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@
 
 import os
 
+import pytest
+
 from django import setup
 from django.conf import settings
 
@@ -15,15 +17,21 @@ import logging
 
 logging.getLogger("factory").setLevel(logging.WARN)
 
+WORKING_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+@pytest.fixture
+def tests_dir():
+    """Helper function to join a path relative to the tests directory."""
+    return lambda path: os.path.join(WORKING_DIR, path)
+
 
 def pytest_configure():
     if not settings.configured:
         from pootle import syspath_override  # Needed for monkey-patching
         syspath_override
         os.environ['DJANGO_SETTINGS_MODULE'] = 'pootle.settings'
-        WORKING_DIR = os.path.abspath(os.path.dirname(__file__))
-        os.environ['POOTLE_SETTINGS'] = os.path.join(WORKING_DIR,
-                                                     'settings.py')
+        os.environ['POOTLE_SETTINGS'] = os.path.join(WORKING_DIR, 'settings.py')
         # The call to `setup()` was needed before a fix for
         # pytest-dev/pytest-django#146 was available. This happened in version
         # 2.9; unfortunately upgrading to 2.9+ is not possible yet because a fix

--- a/tests/core/utils/json.py
+++ b/tests/core/utils/json.py
@@ -8,7 +8,21 @@
 
 import pytest
 
-from pootle.core.utils.json import remove_empty_from_dict
+from pootle.core.utils.json import jsonify, remove_empty_from_dict
+
+
+def test_jsonify_indent_explicit(settings):
+    """Tests jsonify's indent by explicitly passing a value."""
+    settings.DEBUG = False
+    assert jsonify([1], indent=2).count(' ') == 2
+    settings.DEBUG = True
+    assert jsonify([1], indent=2).count(' ') == 2
+
+
+def test_jsonify_indent_debug(settings):
+    """Tests jsonify's indent when `DEBUG = True`."""
+    settings.DEBUG = True
+    assert jsonify([1]).count(' ') == 4
 
 
 @pytest.mark.parametrize('input, expected_output', [

--- a/tests/core/utils/list.py
+++ b/tests/core/utils/list.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Zing contributors.
+#
+# This file is a part of the Zing project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from pootle.core.utils.list import flatten
+
+
+@pytest.mark.parametrize('input, expected', [
+    ([], []),
+    ([1, 2, 3], [1, 2, 3]),
+    ([1, [2], 3], [1, 2, 3]),
+    ([1, [2, 3]], [1, 2, 3]),
+    ([[1], [2, 3], 'foo'], [1, 2, 3, 'foo']),
+    ([[1], [2, [3]], 'foo'], [1, 2, 3, 'foo']),
+    ([[1], [2, [3]], ['foo', 'bar']], [1, 2, 3, 'foo', 'bar']),
+])
+def test_flatten(input, expected):
+    """Tests list flattening."""
+    assert list(flatten(input)) == expected

--- a/tests/data/snapshots/test_browse/admin/_language0_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_language0_.context.json
@@ -1,0 +1,299 @@
+{
+  "announcement": "announcements/language0",
+  "announcements": [
+    "announcements/language0"
+  ],
+  "browse_url": "/language0/",
+  "browser_extends": "languages/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/": {
+        "title": "Project 0",
+        "treeitem_type": 2
+      },
+      "/language0/project1/": {
+        "title": "Project 1",
+        "treeitem_type": 2
+      },
+      "/language0/terminology/": {
+        "title": "Terminology",
+        "treeitem_type": 2
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": {
+    "code": "language0",
+    "name": "Language 0"
+  },
+  "nav": "languages/_nav.html",
+  "object": "Language 0 - language0",
+  "page": "browse",
+  "pootle_path": "/language0/",
+  "project": null,
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/language0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 3288,
+        "reviewed": 0,
+        "suggested": 4365,
+        "translated": 1120,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 711,
+        "reviewed": 3199,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 624,
+        "reviewed": 0,
+        "suggested": 4365,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/translate/#filter=incomplete",
+  "url_action_fixcritical": "/language0/translate/#filter=checks&category=critical",
+  "url_action_review": "/language0/translate/#filter=suggestions",
+  "url_action_view_all": "/language0/translate/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/admin/_language0_project0_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_language0_project0_.context.json
@@ -1,0 +1,306 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/complex.po": {
+        "title": "complex.po"
+      },
+      "/language0/project0/store0.po": {
+        "title": "store0.po"
+      },
+      "/language0/project0/store1.po": {
+        "title": "store1.po"
+      },
+      "/language0/project0/store2.po": {
+        "title": "store2.po"
+      },
+      "/language0/project0/subdir0/": {
+        "title": "subdir0",
+        "treeitem_type": 1
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/",
+    "title": "Back to language"
+  },
+  "pootle_path": "/language0/project0/",
+  "project": "Project 0",
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/language0/project0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/admin/_language0_project0_store0.po.context.json
+++ b/tests/data/snapshots/test_browse/admin/_language0_project0_store0.po.context.json
@@ -1,0 +1,293 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/store0.po",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {}
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/store0.po",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "is_store": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/store0.po",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/store0.po",
+  "project": "Project 0",
+  "resource_path": "store0.po",
+  "resource_path_parts": [
+    "",
+    "store0.po"
+  ],
+  "search_action": "/language0/project0/translate/store0.po",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/store0.po",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/store0.po"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/store0.po#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/store0.po#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/store0.po#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/store0.po#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/store0.po#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/store0.po#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/store0.po#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/admin/_language0_project0_subdir0_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_language0_project0_subdir0_.context.json
@@ -1,0 +1,303 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/subdir0/",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/subdir0/store3.po": {
+        "title": "store3.po"
+      },
+      "/language0/project0/subdir0/store4.po": {
+        "title": "store4.po"
+      },
+      "/language0/project0/subdir0/subdir1/": {
+        "title": "subdir1",
+        "treeitem_type": 1
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/subdir0/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/subdir0/",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/subdir0/",
+  "project": "Project 0",
+  "resource_path": "subdir0/",
+  "resource_path_parts": [
+    "",
+    "subdir0/"
+  ],
+  "search_action": "/language0/project0/translate/subdir0/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/subdir0/",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/subdir0/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/subdir0/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/subdir0/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/subdir0/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/subdir0/#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/subdir0/#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/subdir0/#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/subdir0/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/admin/_language0_project0_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_browse/admin/_language0_project0_subdir0_store4.po.context.json
@@ -1,0 +1,294 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/subdir0/store4.po",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {}
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/subdir0/store4.po",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "is_store": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/subdir0/store4.po",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/subdir0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/subdir0/store4.po",
+  "project": "Project 0",
+  "resource_path": "subdir0/store4.po",
+  "resource_path_parts": [
+    "",
+    "subdir0/",
+    "subdir0/store4.po"
+  ],
+  "search_action": "/language0/project0/translate/subdir0/store4.po",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/subdir0/store4.po",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/subdir0/store4.po"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/subdir0/store4.po#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/subdir0/store4.po#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/subdir0/store4.po#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/subdir0/store4.po#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/admin/_projects_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_projects_.context.json
@@ -1,0 +1,290 @@
+{
+  "browse_url": "/projects/",
+  "browser_extends": "projects/all/base.html",
+  "browsing_data": {
+    "children": {
+      "/projects/project0/": {
+        "title": "Project 0",
+        "treeitem_type": 2
+      },
+      "/projects/project1/": {
+        "title": "Project 1",
+        "treeitem_type": 2
+      },
+      "/projects/terminology/": {
+        "title": "Terminology",
+        "treeitem_type": 2
+      }
+    }
+  },
+  "can_translate": false,
+  "can_translate_stats": false,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/projects/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/projects/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/projects/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/projects/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/projects/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/projects/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/projects/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/projects/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/projects/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/projects/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/projects/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/projects/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/projects/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/projects/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/projects/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/projects/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/projects/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/projects/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/projects/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/projects/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/projects/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/projects/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/projects/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/projects/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/projects/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/projects/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/projects/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/projects/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/projects/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/projects/export-view/",
+  "has_admin_access": false,
+  "is_disabled": true,
+  "language": null,
+  "nav": "projects/all/_nav.html",
+  "object": "/projects/",
+  "page": "browse",
+  "pootle_path": "/projects/",
+  "project": null,
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/projects/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search unavailable\" readonly=\"readonly\" size=\"15\" title=\"\" type=\"text\" disabled /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 5720,
+        "reviewed": 0,
+        "suggested": 7595,
+        "translated": 1950,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 1235,
+        "reviewed": 5563,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1085,
+        "reviewed": 0,
+        "suggested": 7595,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/projects/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/projects/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/projects/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/projects/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/projects/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": null,
+  "url_action_fixcritical": null,
+  "url_action_review": null,
+  "url_action_view_all": null,
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/admin/_projects_project0_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_projects_project0_.context.json
@@ -1,0 +1,292 @@
+{
+  "announcement": "announcements/projects/project0",
+  "announcements": [
+    "announcements/projects/project0"
+  ],
+  "browse_url": "/projects/project0/",
+  "browser_extends": "projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/": {
+        "title": "Language 0",
+        "treeitem_type": 3
+      },
+      "/language1/project0/": {
+        "title": "Language 1",
+        "treeitem_type": 3
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": false,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/projects/project0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/projects/project0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/projects/project0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/projects/project0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/projects/project0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/projects/project0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/projects/project0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/projects/project0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/projects/project0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/projects/project0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/projects/project0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/projects/project0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/projects/project0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/projects/project0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/projects/project0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/projects/project0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/projects/project0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/projects/project0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/projects/project0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/projects/project0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/projects/project0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": true,
+  "is_sidebar_open": true,
+  "language": null,
+  "nav": "projects/_nav.html",
+  "object": "Project 0",
+  "page": "browse",
+  "pootle_path": "/projects/project0/",
+  "project": "Project 0",
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/projects/project0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search unavailable\" readonly=\"readonly\" size=\"15\" title=\"\" type=\"text\" disabled /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 2432,
+        "reviewed": 0,
+        "suggested": 3230,
+        "translated": 830,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 525,
+        "reviewed": 2364,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 461,
+        "reviewed": 0,
+        "suggested": 3230,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/projects/project0/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/projects/project0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/projects/project0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/projects/project0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/projects/project0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": null,
+  "url_action_fixcritical": null,
+  "url_action_review": null,
+  "url_action_view_all": null,
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member/_language0_.context.json
+++ b/tests/data/snapshots/test_browse/member/_language0_.context.json
@@ -1,0 +1,299 @@
+{
+  "announcement": "announcements/language0",
+  "announcements": [
+    "announcements/language0"
+  ],
+  "browse_url": "/language0/",
+  "browser_extends": "languages/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/": {
+        "title": "Project 0",
+        "treeitem_type": 2
+      },
+      "/language0/project1/": {
+        "title": "Project 1",
+        "treeitem_type": 2
+      },
+      "/language0/terminology/": {
+        "title": "Terminology",
+        "treeitem_type": 2
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": {
+    "code": "language0",
+    "name": "Language 0"
+  },
+  "nav": "languages/_nav.html",
+  "object": "Language 0 - language0",
+  "page": "browse",
+  "pootle_path": "/language0/",
+  "project": null,
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/language0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 3288,
+        "reviewed": 0,
+        "suggested": 4365,
+        "translated": 1120,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 711,
+        "reviewed": 3199,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 624,
+        "reviewed": 0,
+        "suggested": 4365,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/translate/#filter=incomplete",
+  "url_action_fixcritical": "/language0/translate/#filter=checks&category=critical",
+  "url_action_review": "/language0/translate/#filter=suggestions",
+  "url_action_view_all": "/language0/translate/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member/_language0_project0_.context.json
+++ b/tests/data/snapshots/test_browse/member/_language0_project0_.context.json
@@ -1,0 +1,306 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/complex.po": {
+        "title": "complex.po"
+      },
+      "/language0/project0/store0.po": {
+        "title": "store0.po"
+      },
+      "/language0/project0/store1.po": {
+        "title": "store1.po"
+      },
+      "/language0/project0/store2.po": {
+        "title": "store2.po"
+      },
+      "/language0/project0/subdir0/": {
+        "title": "subdir0",
+        "treeitem_type": 1
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/",
+    "title": "Back to language"
+  },
+  "pootle_path": "/language0/project0/",
+  "project": "Project 0",
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/language0/project0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member/_language0_project0_store0.po.context.json
+++ b/tests/data/snapshots/test_browse/member/_language0_project0_store0.po.context.json
@@ -1,0 +1,293 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/store0.po",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {}
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/store0.po",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "is_store": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/store0.po",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/store0.po",
+  "project": "Project 0",
+  "resource_path": "store0.po",
+  "resource_path_parts": [
+    "",
+    "store0.po"
+  ],
+  "search_action": "/language0/project0/translate/store0.po",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/store0.po",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/store0.po"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/store0.po#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/store0.po#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/store0.po#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/store0.po#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/store0.po#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/store0.po#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/store0.po#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member/_language0_project0_subdir0_.context.json
+++ b/tests/data/snapshots/test_browse/member/_language0_project0_subdir0_.context.json
@@ -1,0 +1,303 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/subdir0/",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/subdir0/store3.po": {
+        "title": "store3.po"
+      },
+      "/language0/project0/subdir0/store4.po": {
+        "title": "store4.po"
+      },
+      "/language0/project0/subdir0/subdir1/": {
+        "title": "subdir1",
+        "treeitem_type": 1
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/subdir0/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/subdir0/",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/subdir0/",
+  "project": "Project 0",
+  "resource_path": "subdir0/",
+  "resource_path_parts": [
+    "",
+    "subdir0/"
+  ],
+  "search_action": "/language0/project0/translate/subdir0/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/subdir0/",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/subdir0/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/subdir0/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/subdir0/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/subdir0/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/subdir0/#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/subdir0/#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/subdir0/#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/subdir0/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member/_language0_project0_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_browse/member/_language0_project0_subdir0_store4.po.context.json
@@ -1,0 +1,294 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/subdir0/store4.po",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {}
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/subdir0/store4.po",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "is_store": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/subdir0/store4.po",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/subdir0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/subdir0/store4.po",
+  "project": "Project 0",
+  "resource_path": "subdir0/store4.po",
+  "resource_path_parts": [
+    "",
+    "subdir0/",
+    "subdir0/store4.po"
+  ],
+  "search_action": "/language0/project0/translate/subdir0/store4.po",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/subdir0/store4.po",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/subdir0/store4.po"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/subdir0/store4.po#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/subdir0/store4.po#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/subdir0/store4.po#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/subdir0/store4.po#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member/_projects_.context.json
+++ b/tests/data/snapshots/test_browse/member/_projects_.context.json
@@ -1,0 +1,290 @@
+{
+  "browse_url": "/projects/",
+  "browser_extends": "projects/all/base.html",
+  "browsing_data": {
+    "children": {
+      "/projects/project0/": {
+        "title": "Project 0",
+        "treeitem_type": 2
+      },
+      "/projects/project1/": {
+        "title": "Project 1",
+        "treeitem_type": 2
+      },
+      "/projects/terminology/": {
+        "title": "Terminology",
+        "treeitem_type": 2
+      }
+    }
+  },
+  "can_translate": false,
+  "can_translate_stats": false,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/projects/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/projects/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/projects/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/projects/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/projects/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/projects/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/projects/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/projects/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/projects/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/projects/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/projects/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/projects/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/projects/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/projects/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/projects/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/projects/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/projects/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/projects/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/projects/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/projects/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/projects/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/projects/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/projects/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/projects/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/projects/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/projects/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/projects/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/projects/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/projects/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/projects/export-view/",
+  "has_admin_access": false,
+  "is_disabled": true,
+  "language": null,
+  "nav": "projects/all/_nav.html",
+  "object": "/projects/",
+  "page": "browse",
+  "pootle_path": "/projects/",
+  "project": null,
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/projects/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search unavailable\" readonly=\"readonly\" size=\"15\" title=\"\" type=\"text\" disabled /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 5720,
+        "reviewed": 0,
+        "suggested": 7595,
+        "translated": 1950,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 1235,
+        "reviewed": 5563,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1085,
+        "reviewed": 0,
+        "suggested": 7595,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/projects/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/projects/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/projects/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/projects/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/projects/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": null,
+  "url_action_fixcritical": null,
+  "url_action_review": null,
+  "url_action_view_all": null,
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member/_projects_project0_.context.json
+++ b/tests/data/snapshots/test_browse/member/_projects_project0_.context.json
@@ -1,0 +1,292 @@
+{
+  "announcement": "announcements/projects/project0",
+  "announcements": [
+    "announcements/projects/project0"
+  ],
+  "browse_url": "/projects/project0/",
+  "browser_extends": "projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/": {
+        "title": "Language 0",
+        "treeitem_type": 3
+      },
+      "/language1/project0/": {
+        "title": "Language 1",
+        "treeitem_type": 3
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": false,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/projects/project0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/projects/project0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/projects/project0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/projects/project0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/projects/project0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/projects/project0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/projects/project0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/projects/project0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/projects/project0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/projects/project0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/projects/project0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/projects/project0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/projects/project0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/projects/project0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/projects/project0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/projects/project0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/projects/project0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/projects/project0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/projects/project0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/projects/project0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/projects/project0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": true,
+  "is_sidebar_open": true,
+  "language": null,
+  "nav": "projects/_nav.html",
+  "object": "Project 0",
+  "page": "browse",
+  "pootle_path": "/projects/project0/",
+  "project": "Project 0",
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/projects/project0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search unavailable\" readonly=\"readonly\" size=\"15\" title=\"\" type=\"text\" disabled /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 2432,
+        "reviewed": 0,
+        "suggested": 3230,
+        "translated": 830,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 525,
+        "reviewed": 2364,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 461,
+        "reviewed": 0,
+        "suggested": 3230,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/projects/project0/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/projects/project0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/projects/project0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/projects/project0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/projects/project0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": null,
+  "url_action_fixcritical": null,
+  "url_action_review": null,
+  "url_action_view_all": null,
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member2/_language0_.context.json
+++ b/tests/data/snapshots/test_browse/member2/_language0_.context.json
@@ -1,0 +1,299 @@
+{
+  "announcement": "announcements/language0",
+  "announcements": [
+    "announcements/language0"
+  ],
+  "browse_url": "/language0/",
+  "browser_extends": "languages/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/": {
+        "title": "Project 0",
+        "treeitem_type": 2
+      },
+      "/language0/project1/": {
+        "title": "Project 1",
+        "treeitem_type": 2
+      },
+      "/language0/terminology/": {
+        "title": "Terminology",
+        "treeitem_type": 2
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": {
+    "code": "language0",
+    "name": "Language 0"
+  },
+  "nav": "languages/_nav.html",
+  "object": "Language 0 - language0",
+  "page": "browse",
+  "pootle_path": "/language0/",
+  "project": null,
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/language0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 3288,
+        "reviewed": 0,
+        "suggested": 4365,
+        "translated": 1120,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 711,
+        "reviewed": 3199,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 624,
+        "reviewed": 0,
+        "suggested": 4365,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/translate/#filter=incomplete",
+  "url_action_fixcritical": "/language0/translate/#filter=checks&category=critical",
+  "url_action_review": "/language0/translate/#filter=suggestions",
+  "url_action_view_all": "/language0/translate/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member2/_language0_project0_.context.json
+++ b/tests/data/snapshots/test_browse/member2/_language0_project0_.context.json
@@ -1,0 +1,306 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/complex.po": {
+        "title": "complex.po"
+      },
+      "/language0/project0/store0.po": {
+        "title": "store0.po"
+      },
+      "/language0/project0/store1.po": {
+        "title": "store1.po"
+      },
+      "/language0/project0/store2.po": {
+        "title": "store2.po"
+      },
+      "/language0/project0/subdir0/": {
+        "title": "subdir0",
+        "treeitem_type": 1
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/",
+    "title": "Back to language"
+  },
+  "pootle_path": "/language0/project0/",
+  "project": "Project 0",
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/language0/project0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member2/_language0_project0_store0.po.context.json
+++ b/tests/data/snapshots/test_browse/member2/_language0_project0_store0.po.context.json
@@ -1,0 +1,293 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/store0.po",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {}
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/store0.po",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "is_store": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/store0.po",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/store0.po",
+  "project": "Project 0",
+  "resource_path": "store0.po",
+  "resource_path_parts": [
+    "",
+    "store0.po"
+  ],
+  "search_action": "/language0/project0/translate/store0.po",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/store0.po",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/store0.po"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/store0.po#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/store0.po#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/store0.po#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/store0.po#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/store0.po#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/store0.po#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/store0.po#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member2/_language0_project0_subdir0_.context.json
+++ b/tests/data/snapshots/test_browse/member2/_language0_project0_subdir0_.context.json
@@ -1,0 +1,303 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/subdir0/",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/subdir0/store3.po": {
+        "title": "store3.po"
+      },
+      "/language0/project0/subdir0/store4.po": {
+        "title": "store4.po"
+      },
+      "/language0/project0/subdir0/subdir1/": {
+        "title": "subdir1",
+        "treeitem_type": 1
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/subdir0/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/subdir0/",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/subdir0/",
+  "project": "Project 0",
+  "resource_path": "subdir0/",
+  "resource_path_parts": [
+    "",
+    "subdir0/"
+  ],
+  "search_action": "/language0/project0/translate/subdir0/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/subdir0/",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/subdir0/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/subdir0/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/subdir0/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/subdir0/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/subdir0/#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/subdir0/#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/subdir0/#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/subdir0/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member2/_language0_project0_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_browse/member2/_language0_project0_subdir0_store4.po.context.json
@@ -1,0 +1,294 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/subdir0/store4.po",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {}
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/subdir0/store4.po",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "is_store": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/subdir0/store4.po",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/subdir0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/subdir0/store4.po",
+  "project": "Project 0",
+  "resource_path": "subdir0/store4.po",
+  "resource_path_parts": [
+    "",
+    "subdir0/",
+    "subdir0/store4.po"
+  ],
+  "search_action": "/language0/project0/translate/subdir0/store4.po",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/subdir0/store4.po",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/subdir0/store4.po"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/subdir0/store4.po#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/subdir0/store4.po#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/subdir0/store4.po#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/subdir0/store4.po#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member2/_projects_.context.json
+++ b/tests/data/snapshots/test_browse/member2/_projects_.context.json
@@ -1,0 +1,290 @@
+{
+  "browse_url": "/projects/",
+  "browser_extends": "projects/all/base.html",
+  "browsing_data": {
+    "children": {
+      "/projects/project0/": {
+        "title": "Project 0",
+        "treeitem_type": 2
+      },
+      "/projects/project1/": {
+        "title": "Project 1",
+        "treeitem_type": 2
+      },
+      "/projects/terminology/": {
+        "title": "Terminology",
+        "treeitem_type": 2
+      }
+    }
+  },
+  "can_translate": false,
+  "can_translate_stats": false,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/projects/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/projects/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/projects/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/projects/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/projects/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/projects/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/projects/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/projects/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/projects/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/projects/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/projects/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/projects/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/projects/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/projects/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/projects/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/projects/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/projects/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/projects/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/projects/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/projects/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/projects/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/projects/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/projects/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/projects/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/projects/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/projects/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/projects/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/projects/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/projects/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/projects/export-view/",
+  "has_admin_access": false,
+  "is_disabled": true,
+  "language": null,
+  "nav": "projects/all/_nav.html",
+  "object": "/projects/",
+  "page": "browse",
+  "pootle_path": "/projects/",
+  "project": null,
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/projects/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search unavailable\" readonly=\"readonly\" size=\"15\" title=\"\" type=\"text\" disabled /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 5720,
+        "reviewed": 0,
+        "suggested": 7595,
+        "translated": 1950,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 1235,
+        "reviewed": 5563,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1085,
+        "reviewed": 0,
+        "suggested": 7595,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/projects/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/projects/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/projects/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/projects/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/projects/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": null,
+  "url_action_fixcritical": null,
+  "url_action_review": null,
+  "url_action_view_all": null,
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/member2/_projects_project0_.context.json
+++ b/tests/data/snapshots/test_browse/member2/_projects_project0_.context.json
@@ -1,0 +1,292 @@
+{
+  "announcement": "announcements/projects/project0",
+  "announcements": [
+    "announcements/projects/project0"
+  ],
+  "browse_url": "/projects/project0/",
+  "browser_extends": "projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/": {
+        "title": "Language 0",
+        "treeitem_type": 3
+      },
+      "/language1/project0/": {
+        "title": "Language 1",
+        "treeitem_type": 3
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": false,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/projects/project0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/projects/project0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/projects/project0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/projects/project0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/projects/project0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/projects/project0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/projects/project0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/projects/project0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/projects/project0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/projects/project0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/projects/project0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/projects/project0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/projects/project0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/projects/project0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/projects/project0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/projects/project0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/projects/project0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/projects/project0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/projects/project0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/projects/project0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/projects/project0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": true,
+  "is_sidebar_open": true,
+  "language": null,
+  "nav": "projects/_nav.html",
+  "object": "Project 0",
+  "page": "browse",
+  "pootle_path": "/projects/project0/",
+  "project": "Project 0",
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/projects/project0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search unavailable\" readonly=\"readonly\" size=\"15\" title=\"\" type=\"text\" disabled /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 2432,
+        "reviewed": 0,
+        "suggested": 3230,
+        "translated": 830,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 525,
+        "reviewed": 2364,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 461,
+        "reviewed": 0,
+        "suggested": 3230,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/projects/project0/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/projects/project0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/projects/project0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/projects/project0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/projects/project0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": null,
+  "url_action_fixcritical": null,
+  "url_action_review": null,
+  "url_action_view_all": null,
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/nobody/_language0_.context.json
+++ b/tests/data/snapshots/test_browse/nobody/_language0_.context.json
@@ -1,0 +1,299 @@
+{
+  "announcement": "announcements/language0",
+  "announcements": [
+    "announcements/language0"
+  ],
+  "browse_url": "/language0/",
+  "browser_extends": "languages/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/": {
+        "title": "Project 0",
+        "treeitem_type": 2
+      },
+      "/language0/project1/": {
+        "title": "Project 1",
+        "treeitem_type": 2
+      },
+      "/language0/terminology/": {
+        "title": "Terminology",
+        "treeitem_type": 2
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": {
+    "code": "language0",
+    "name": "Language 0"
+  },
+  "nav": "languages/_nav.html",
+  "object": "Language 0 - language0",
+  "page": "browse",
+  "pootle_path": "/language0/",
+  "project": null,
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/language0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 3288,
+        "reviewed": 0,
+        "suggested": 4365,
+        "translated": 1120,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 711,
+        "reviewed": 3199,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 624,
+        "reviewed": 0,
+        "suggested": 4365,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/translate/#filter=incomplete",
+  "url_action_fixcritical": "/language0/translate/#filter=checks&category=critical",
+  "url_action_review": "/language0/translate/#filter=suggestions",
+  "url_action_view_all": "/language0/translate/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/nobody/_language0_project0_.context.json
+++ b/tests/data/snapshots/test_browse/nobody/_language0_project0_.context.json
@@ -1,0 +1,306 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/complex.po": {
+        "title": "complex.po"
+      },
+      "/language0/project0/store0.po": {
+        "title": "store0.po"
+      },
+      "/language0/project0/store1.po": {
+        "title": "store1.po"
+      },
+      "/language0/project0/store2.po": {
+        "title": "store2.po"
+      },
+      "/language0/project0/subdir0/": {
+        "title": "subdir0",
+        "treeitem_type": 1
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/",
+    "title": "Back to language"
+  },
+  "pootle_path": "/language0/project0/",
+  "project": "Project 0",
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/language0/project0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/nobody/_language0_project0_store0.po.context.json
+++ b/tests/data/snapshots/test_browse/nobody/_language0_project0_store0.po.context.json
@@ -1,0 +1,293 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/store0.po",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {}
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/store0.po#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/store0.po",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "is_store": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/store0.po",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/store0.po",
+  "project": "Project 0",
+  "resource_path": "store0.po",
+  "resource_path_parts": [
+    "",
+    "store0.po"
+  ],
+  "search_action": "/language0/project0/translate/store0.po",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/store0.po",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/store0.po"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/store0.po#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/store0.po#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/store0.po#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/store0.po#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/store0.po#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/store0.po#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/store0.po#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/nobody/_language0_project0_subdir0_.context.json
+++ b/tests/data/snapshots/test_browse/nobody/_language0_project0_subdir0_.context.json
@@ -1,0 +1,303 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/subdir0/",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/subdir0/store3.po": {
+        "title": "store3.po"
+      },
+      "/language0/project0/subdir0/store4.po": {
+        "title": "store4.po"
+      },
+      "/language0/project0/subdir0/subdir1/": {
+        "title": "subdir1",
+        "treeitem_type": 1
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/subdir0/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/subdir0/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/subdir0/",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/subdir0/",
+  "project": "Project 0",
+  "resource_path": "subdir0/",
+  "resource_path_parts": [
+    "",
+    "subdir0/"
+  ],
+  "search_action": "/language0/project0/translate/subdir0/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/subdir0/",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/subdir0/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/subdir0/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/subdir0/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/subdir0/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/subdir0/#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/subdir0/#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/subdir0/#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/subdir0/#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/nobody/_language0_project0_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_browse/nobody/_language0_project0_subdir0_store4.po.context.json
@@ -1,0 +1,294 @@
+{
+  "announcement": "announcements/language0/project0",
+  "announcements": [
+    "announcements/projects/project0",
+    "announcements/language0",
+    "announcements/language0/project0"
+  ],
+  "browse_url": "/language0/project0/subdir0/store4.po",
+  "browser_extends": "translation_projects/base.html",
+  "browsing_data": {
+    "children": {}
+  },
+  "can_translate": true,
+  "can_translate_stats": true,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/language0/project0/export-view/subdir0/store4.po",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": false,
+  "is_sidebar_open": true,
+  "is_store": true,
+  "language": "Language 0 - language0",
+  "nav": "translation_projects/_nav.html",
+  "object": "/language0/project0/subdir0/store4.po",
+  "page": "browse",
+  "parent": {
+    "href": "/language0/project0/subdir0/",
+    "title": "Back to parent folder"
+  },
+  "pootle_path": "/language0/project0/subdir0/store4.po",
+  "project": "Project 0",
+  "resource_path": "subdir0/store4.po",
+  "resource_path_parts": [
+    "",
+    "subdir0/",
+    "subdir0/store4.po"
+  ],
+  "search_action": "/language0/project0/translate/subdir0/store4.po",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1216,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 415,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 262,
+        "reviewed": 1182,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 231,
+        "reviewed": 0,
+        "suggested": 1615,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/language0/project0/translate/subdir0/store4.po",
+  "translation_project": "/language0/project0/",
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/language0/project0/translate/subdir0/store4.po"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/language0/project0/translate/subdir0/store4.po#filter=untranslated"
+    }
+  ],
+  "url_action_continue": "/language0/project0/translate/subdir0/store4.po#filter=incomplete",
+  "url_action_fixcritical": "/language0/project0/translate/subdir0/store4.po#filter=checks&category=critical",
+  "url_action_review": "/language0/project0/translate/subdir0/store4.po#filter=suggestions",
+  "url_action_view_all": "/language0/project0/translate/subdir0/store4.po#filter=all",
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/nobody/_projects_.context.json
+++ b/tests/data/snapshots/test_browse/nobody/_projects_.context.json
@@ -1,0 +1,290 @@
+{
+  "browse_url": "/projects/",
+  "browser_extends": "projects/all/base.html",
+  "browsing_data": {
+    "children": {
+      "/projects/project0/": {
+        "title": "Project 0",
+        "treeitem_type": 2
+      },
+      "/projects/project1/": {
+        "title": "Project 1",
+        "treeitem_type": 2
+      },
+      "/projects/terminology/": {
+        "title": "Terminology",
+        "treeitem_type": 2
+      }
+    }
+  },
+  "can_translate": false,
+  "can_translate_stats": false,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/projects/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/projects/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/projects/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/projects/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/projects/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/projects/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/projects/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/projects/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/projects/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/projects/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/projects/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/projects/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/projects/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/projects/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/projects/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/projects/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/projects/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/projects/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/projects/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/projects/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/projects/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/projects/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/projects/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/projects/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/projects/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/projects/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/projects/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/projects/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/projects/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/projects/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/projects/export-view/",
+  "has_admin_access": false,
+  "is_disabled": true,
+  "language": null,
+  "nav": "projects/all/_nav.html",
+  "object": "/projects/",
+  "page": "browse",
+  "pootle_path": "/projects/",
+  "project": null,
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/projects/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search unavailable\" readonly=\"readonly\" size=\"15\" title=\"\" type=\"text\" disabled /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 5720,
+        "reviewed": 0,
+        "suggested": 7595,
+        "translated": 1950,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 1235,
+        "reviewed": 5563,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 1085,
+        "reviewed": 0,
+        "suggested": 7595,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/projects/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/projects/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/projects/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/projects/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/projects/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": null,
+  "url_action_fixcritical": null,
+  "url_action_review": null,
+  "url_action_view_all": null,
+  "user": "nobody"
+}

--- a/tests/data/snapshots/test_browse/nobody/_projects_project0_.context.json
+++ b/tests/data/snapshots/test_browse/nobody/_projects_project0_.context.json
@@ -1,0 +1,292 @@
+{
+  "announcement": "announcements/projects/project0",
+  "announcements": [
+    "announcements/projects/project0"
+  ],
+  "browse_url": "/projects/project0/",
+  "browser_extends": "projects/base.html",
+  "browsing_data": {
+    "children": {
+      "/language0/project0/": {
+        "title": "Language 0",
+        "treeitem_type": 3
+      },
+      "/language1/project0/": {
+        "title": "Language 1",
+        "treeitem_type": 3
+      }
+    }
+  },
+  "can_translate": true,
+  "can_translate_stats": false,
+  "checks": [
+    {
+      "code": "dollar_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "$ closure placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=dollar_sign_closure_placeholders"
+    },
+    {
+      "code": "dollar_sign_placeholders",
+      "is_critical": true,
+      "title": "$ placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=dollar_sign_placeholders"
+    },
+    {
+      "code": "accelerators",
+      "is_critical": true,
+      "title": "Accelerators",
+      "url": "/projects/project0/translate/#filter=checks&checks=accelerators"
+    },
+    {
+      "code": "android_format",
+      "is_critical": true,
+      "title": "Android format",
+      "url": "/projects/project0/translate/#filter=checks&checks=android_format"
+    },
+    {
+      "code": "broken_entities",
+      "is_critical": true,
+      "title": "Broken HTML Entities",
+      "url": "/projects/project0/translate/#filter=checks&checks=broken_entities"
+    },
+    {
+      "code": "c_format",
+      "is_critical": true,
+      "title": "C format placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=c_format"
+    },
+    {
+      "code": "changed_attributes",
+      "is_critical": true,
+      "title": "Changed attributes",
+      "url": "/projects/project0/translate/#filter=checks&checks=changed_attributes"
+    },
+    {
+      "code": "unbalanced_curly_braces",
+      "is_critical": true,
+      "title": "Curly braces",
+      "url": "/projects/project0/translate/#filter=checks&checks=unbalanced_curly_braces"
+    },
+    {
+      "code": "date_format",
+      "is_critical": true,
+      "title": "Date format",
+      "url": "/projects/project0/translate/#filter=checks&checks=date_format"
+    },
+    {
+      "code": "double_quotes_in_tags",
+      "is_critical": true,
+      "title": "Double quotes in tags",
+      "url": "/projects/project0/translate/#filter=checks&checks=double_quotes_in_tags"
+    },
+    {
+      "code": "incorrectly_escaped_ampersands",
+      "is_critical": true,
+      "title": "Incorrectly escaped ampersands",
+      "url": "/projects/project0/translate/#filter=checks&checks=incorrectly_escaped_ampersands"
+    },
+    {
+      "code": "java_format",
+      "is_critical": true,
+      "title": "Java format",
+      "url": "/projects/project0/translate/#filter=checks&checks=java_format"
+    },
+    {
+      "code": "javaencoded_unicode",
+      "is_critical": true,
+      "title": "Java-encoded unicode",
+      "url": "/projects/project0/translate/#filter=checks&checks=javaencoded_unicode"
+    },
+    {
+      "code": "mustache_like_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache like placeholder pairs",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_like_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholder_pairs",
+      "is_critical": true,
+      "title": "Mustache placeholder pairs",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_placeholder_pairs"
+    },
+    {
+      "code": "mustache_placeholders",
+      "is_critical": true,
+      "title": "Mustache placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=mustache_placeholders"
+    },
+    {
+      "code": "non_printable",
+      "is_critical": true,
+      "title": "Non printable",
+      "url": "/projects/project0/translate/#filter=checks&checks=non_printable"
+    },
+    {
+      "code": "objective_c_format",
+      "is_critical": true,
+      "title": "Objective-C format",
+      "url": "/projects/project0/translate/#filter=checks&checks=objective_c_format"
+    },
+    {
+      "code": "percent_brace_placeholders",
+      "is_critical": true,
+      "title": "Percent brace placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_brace_placeholders"
+    },
+    {
+      "code": "percent_sign_closure_placeholders",
+      "is_critical": true,
+      "title": "Percent sign closure placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_sign_closure_placeholders"
+    },
+    {
+      "code": "percent_sign_placeholders",
+      "is_critical": true,
+      "title": "Percent sign placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=percent_sign_placeholders"
+    },
+    {
+      "code": "plurr_format",
+      "is_critical": true,
+      "title": "Plurr format",
+      "url": "/projects/project0/translate/#filter=checks&checks=plurr_format"
+    },
+    {
+      "code": "plurr_placeholders",
+      "is_critical": true,
+      "title": "Plurr placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=plurr_placeholders"
+    },
+    {
+      "code": "potential_unwanted_placeholders",
+      "is_critical": true,
+      "title": "Potential unwanted placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=potential_unwanted_placeholders"
+    },
+    {
+      "code": "tags_differ",
+      "is_critical": true,
+      "title": "Tags differ",
+      "url": "/projects/project0/translate/#filter=checks&checks=tags_differ"
+    },
+    {
+      "code": "template_format",
+      "is_critical": true,
+      "title": "Template format",
+      "url": "/projects/project0/translate/#filter=checks&checks=template_format"
+    },
+    {
+      "code": "test_check",
+      "is_critical": true,
+      "title": "test_check",
+      "url": "/projects/project0/translate/#filter=checks&checks=test_check"
+    },
+    {
+      "code": "unbalanced_tag_braces",
+      "is_critical": true,
+      "title": "Unbalanced tag braces",
+      "url": "/projects/project0/translate/#filter=checks&checks=unbalanced_tag_braces"
+    },
+    {
+      "code": "unescaped_ampersands",
+      "is_critical": true,
+      "title": "Unescaped ampersands",
+      "url": "/projects/project0/translate/#filter=checks&checks=unescaped_ampersands"
+    },
+    {
+      "code": "uppercase_placeholders",
+      "is_critical": true,
+      "title": "Uppercase placeholders",
+      "url": "/projects/project0/translate/#filter=checks&checks=uppercase_placeholders"
+    },
+    {
+      "code": "whitespace",
+      "is_critical": true,
+      "title": "Whitespaces",
+      "url": "/projects/project0/translate/#filter=checks&checks=whitespace"
+    },
+    {
+      "code": "doublequoting",
+      "is_critical": false,
+      "title": "Double quotes",
+      "url": "/projects/project0/translate/#filter=checks&checks=doublequoting"
+    }
+  ],
+  "export_url": "/projects/project0/export-view/",
+  "has_admin_access": false,
+  "has_sidebar": true,
+  "is_disabled": true,
+  "is_sidebar_open": true,
+  "language": null,
+  "nav": "projects/_nav.html",
+  "object": "Project 0",
+  "page": "browse",
+  "pootle_path": "/projects/project0/",
+  "project": "Project 0",
+  "resource_path": "",
+  "resource_path_parts": [],
+  "search_action": "/projects/project0/translate/",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search unavailable\" readonly=\"readonly\" size=\"15\" title=\"\" type=\"text\" disabled /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "stats_refresh_attempts_count": 2,
+  "top_scorers": {
+    "items": [
+      {
+        "display_name": "Member",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 2432,
+        "reviewed": 0,
+        "suggested": 3230,
+        "translated": 830,
+        "username": "member"
+      },
+      {
+        "display_name": "Admin",
+        "email": "71fdc4f9ffe0d168ac7ab64ba4caf249",
+        "public_total_score": 525,
+        "reviewed": 2364,
+        "suggested": 0,
+        "translated": 0,
+        "username": "admin"
+      },
+      {
+        "display_name": "Member2",
+        "email": "d41d8cd98f00b204e9800998ecf8427e",
+        "public_total_score": 461,
+        "reviewed": 0,
+        "suggested": 3230,
+        "translated": 0,
+        "username": "member2"
+      }
+    ]
+  },
+  "translate_url": "/projects/project0/translate/",
+  "translation_project": null,
+  "translation_states": [
+    {
+      "state": "total",
+      "title": "Total",
+      "url": "/projects/project0/translate/"
+    },
+    {
+      "state": "translated",
+      "title": "Translated",
+      "url": "/projects/project0/translate/#filter=translated"
+    },
+    {
+      "state": "fuzzy",
+      "title": "Fuzzy",
+      "url": "/projects/project0/translate/#filter=fuzzy"
+    },
+    {
+      "state": "untranslated",
+      "title": "Untranslated",
+      "url": "/projects/project0/translate/#filter=untranslated"
+    }
+  ],
+  "url_action_continue": null,
+  "url_action_fixcritical": null,
+  "url_action_review": null,
+  "url_action_view_all": null,
+  "user": "nobody"
+}

--- a/tests/models/snapshot.py
+++ b/tests/models/snapshot.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Zing contributors.
+#
+# This file is a part of the Zing project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from django.template import Context
+from django.test.utils import ContextList
+
+from pootle.core.models.snapshot import Snapshot, SnapshotStack
+
+
+@pytest.mark.parametrize('bogus_filepath', [
+    '../test',
+    '../../test',
+    '../foo/../bar/../test',
+])
+def test_snapshot_filepath_out_of_data_dir(tmpdir, bogus_filepath):
+    """Tests files cannot fall anywhere but under `data_dir`."""
+    reference_file = tmpdir.join('non-existant')
+    snapshot = Snapshot(bogus_filepath, data_dir=reference_file.dirname)
+    with pytest.raises(ValueError):
+        snapshot.filepath
+
+
+def test_snapshot_filepath(tmpdir):
+    """Tests file paths fall under `data_dir`."""
+    reference_file = tmpdir.join('foo')
+    snapshot = Snapshot('foo', data_dir=reference_file.dirname)
+    snapshot.filepath == reference_file
+
+
+def test_snapshot_reference_non_existant():
+    """Tests snapshots for non-existant references."""
+    snapshot = Snapshot('bogus')
+    assert snapshot.reference is None
+
+
+def test_snapshot_reference(tmpdir):
+    """Tests snapshot references are loaded."""
+    reference_file = tmpdir.join('test.json')
+    snapshot = Snapshot('test', data_dir=reference_file.dirname)
+    reference_content = 'FOO'
+    reference_file.write(reference_content)
+    assert snapshot.reference == reference_content
+
+
+@pytest.mark.parametrize('input, clean_output', [
+    (None, None),
+    ([], []),
+
+    ({'foo': 'bar'}, {'foo': 'bar'}),
+    ({'block': True, 'forloop': False, 'lastupdated': 1234}, {}),
+
+    ([{'foo': 'bar'}], [{'foo': 'bar'}]),
+    ([{'block': True}, {'forloop': False, 'lastupdated': 1234}], [{}, {}]),
+
+    (ContextList([Context({'foo': 'bar'})]), {'foo': 'bar'}),
+    (ContextList([Context({'block': True})]), {}),
+    (ContextList([Context({'block': True}), Context({'foo': 'bar'})]),
+     {'foo': 'bar'}),
+])
+def test_snapshot_clean(input, clean_output):
+    """Tests the cleanup of snapshot contexts."""
+    snapshot = Snapshot('test')
+    assert snapshot.clean(input) == clean_output
+
+
+def test_snapshot_assert_matches_generate(tmpdir):
+    """Tests the snapshot is generated if instructed to do so."""
+    reference_file = tmpdir.join('test.json')
+    snapshot = Snapshot('test', data_dir=reference_file.dirname, generate=True)
+    assert snapshot.reference is None
+    # The assertion function reported nothing
+    assert snapshot.assert_matches({}) is None
+    # But the reference file should now be created
+    assert reference_file.exists()
+
+
+def test_snapshot_assert_matches_generate_subdirs(tmpdir):
+    """Tests the snapshot is generated also with subdirectories."""
+    reference_file = tmpdir.join('non-existant')
+    snapshot = Snapshot('subdir/test', data_dir=reference_file.dirname,
+                        generate=True)
+    assert snapshot.reference is None
+    # The assertion function reported nothing
+    assert snapshot.assert_matches({}) is None
+    # But the reference dir + file should now be created
+    assert reference_file.join('../subdir/test.json').exists()
+
+
+def test_snapshot_assert_matches_generate_subdirs_existing(tmpdir):
+    """Tests the snapshot is generated also with existing subdirectories."""
+    reference_file = tmpdir.join('subdir')
+    snapshot = Snapshot('subdir/test', data_dir=reference_file.dirname,
+                        generate=True)
+    assert snapshot.reference is None
+    # The assertion function reported nothing
+    assert snapshot.assert_matches({}) is None
+    # But the reference dir + file should now be created
+    assert reference_file.join('test.json').exists()
+
+
+def test_snapshot_assert_matches_error(tmpdir):
+    """Tests assertion errors out if the reference does not exist."""
+    reference_file = tmpdir.join('test.json')
+    snapshot = Snapshot('test', data_dir=reference_file.dirname)
+    assert snapshot.reference is None
+    with pytest.raises(AssertionError):
+        snapshot.assert_matches({'foo': 'bar'})
+
+
+def test_snapshot_assert_matches(tmpdir):
+    """Tests assertion matching."""
+    reference_file = tmpdir.join('test.json')
+    snapshot = Snapshot('test', data_dir=reference_file.dirname)
+    reference_content = 'FOO'
+    reference_file.write(snapshot.serialize(reference_content))
+    snapshot.assert_matches(reference_content)
+
+
+@pytest.mark.parametrize('stack_values, expected_ctx_name', [
+    ('', ''),
+    ('/', ''),
+    (['/'], ''),
+
+    (['/', 'foo'], 'foo'),
+    (['/', 'foo', '/'], 'foo'),
+    (['/', 'foo', ''], 'foo'),
+
+    (['/foo', 'bar'], 'foo.bar'),
+    (['foo', '/bar'], 'foo.bar'),
+    (['foo', '/', 'bar'], 'foo.bar'),
+
+    (['foo/', 'bar'], 'foo/bar'),
+    (['foo/', 'bar/', 'baz'], 'foo/bar/baz'),
+    (['foo/', 'bar/', '/baz'], 'foo/bar/baz'),
+    (['foo/bar/baz'], 'foo/bar/baz'),
+    ('foo/bar/baz', 'foo/bar/baz'),
+
+    (['foo', 'bar/'], 'foo.bar/'),
+    (['foo/bar/baz', 'blah'], 'foo/bar/baz.blah'),
+])
+def test_snapshot_stack_ctx_name(stack_values, expected_ctx_name):
+    """Tests SnapshotStack's context name generation."""
+    stack = SnapshotStack({})
+    stack.push(stack_values)
+    assert stack.ctx_name == expected_ctx_name

--- a/tests/views/browse.py
+++ b/tests/views/browse.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Zing contributors.
+#
+# This file is a part of the Zing project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from pytest_pootle.utils import as_dir, url_name
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('url', [
+    '/projects/',
+    '/projects/project0/',
+    '/language0/',
+    '/language0/project0/',
+    '/language0/project0/store0.po',
+    '/language0/project0/subdir0/',
+    '/language0/project0/subdir0/store4.po',
+])
+def test_browse(client, request_users, test_name, flush_redis,
+                snapshot_stack, url):
+    """Tests correctness of the browsing view context."""
+    user = request_users['user']
+
+    with snapshot_stack.push([
+        as_dir(test_name), as_dir(user.username), url_name(url)
+    ]):
+        if not user.is_anonymous():
+            client.login(username=user.username, password=user.password)
+        response = client.get(url)
+        assert response.status_code == 200
+
+        with snapshot_stack.push('context') as snapshot:
+            snapshot.assert_matches(response.context)


### PR DESCRIPTION
~_Note: This is pretty much a proof of concept and a work in progress_~

The PR implements snapshot testing for views.

The concept is simple: request a view via a URL and dump the rendered context to a JSON file. A human needs to evaluate first whether the rendered context is valid or not.

Afterwards, the verification process compares the expected context with the context generated by the test run. If they match, the test passes; fails otherwise.

Fixes #45.