### PR TITLE
Checks: default to a site-wide checker

### DIFF
--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -422,7 +422,7 @@ Translation environment configuration settings.
 .. setting:: POOTLE_QUALITY_CHECKER
 
 ``POOTLE_QUALITY_CHECKER``
-  Default: ``''``
+  Default: ``'pootle_misc.checks.ENChecker'``
 
   .. versionadded:: 2.7
 

--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -280,7 +281,12 @@ class ENChecker(checks.UnitChecker):
         self.str1 = data.normalized_unicode(unit.source) or u''
         self.str2 = data.normalized_unicode(unit.target) or u''
 
-        self.language_code = unit.store.translation_project.language.code
+        # FIXME: avoid this
+        from pootle.core.checks.checker import CheckableUnit
+        if isinstance(unit, CheckableUnit):
+            self.language_code = unit.language_code
+        else:
+            self.language_code = unit.store.translation_project.language.code
 
         return super(ENChecker, self).run_filters(unit, categorised)
 

--- a/pootle/settings/60-translation.conf
+++ b/pootle/settings/60-translation.conf
@@ -58,7 +58,5 @@ POOTLE_WORDCOUNT_FUNC = 'translate.storage.statsdb.wordcount'
 # Quality checks
 #
 # Override checker class.  Supply your own quality checker functions by
-# supplying the class to use for quality checks.  Default of '' ensures that
-# the quality checks defined in the project setup are used instead.  Available
-# alternate checkers are: 'pootle_misc.checks.ENChecker'
-POOTLE_QUALITY_CHECKER = ''
+# supplying the class to use for quality checks.
+POOTLE_QUALITY_CHECKER = 'pootle_misc.checks.ENChecker'

--- a/tests/commands/test_checks.py
+++ b/tests/commands/test_checks.py
@@ -74,15 +74,3 @@ def test_test_checks_srctgt_fail(capfd):
     call_command('test_checks', '--source="%s files"', '--target="%d leers"')
     out, err = capfd.readouterr()
     assert 'Failing checks' in out
-
-
-@pytest.mark.cmd
-def test_test_checks_alt_checker(capfd, settings):
-    """Use an alternate checker."""
-    settings.POOTLE_QUALITY_CHECKER = 'pootle_misc.checks.ENChecker'
-    call_command('test_checks', '--source="%s files"', '--target="%s leers"')
-    out, err = capfd.readouterr()
-    assert 'No errors found' in out
-    call_command('test_checks', '--source="%s files"', '--target="%d leers"')
-    out, err = capfd.readouterr()
-    assert 'Failing checks' in out


### PR DESCRIPTION
The source of interchange files can be various, so checkers should rather be
site-wide, as projects can contain files from various sources.