### PR TITLE
Browser: do not store children data in a list

### DIFF
--- a/pootle/core/views/browse.py
+++ b/pootle/core/views/browse.py
@@ -42,8 +42,7 @@ class BrowseDataViewMixin(object):
         :param stats: Dictionary containing stats for this particular
             `path_obj`.
         """
-        return {
-            'pootle_path': path_obj.pootle_path,
+        return (path_obj.pootle_path, {
             # FIXME: rename to `type`
             'treeitem_type': self.get_item_type(path_obj),
             'title': self.get_item_title(path_obj),
@@ -56,7 +55,7 @@ class BrowseDataViewMixin(object):
             'suggestions': stats.get('suggestions', 0),
             'lastaction': stats.get('lastaction', 0),
             'lastupdated': stats.get('lastupdated', 0),
-        }
+        })
 
     def get_browsing_data(self):
         browsing_data = remove_empty_from_dict({
@@ -66,12 +65,13 @@ class BrowseDataViewMixin(object):
         })
         children_stats = self.stats['children']
         browsing_data.update({
-            'children': [
-                remove_empty_from_dict(
+            'children': {
+                path: remove_empty_from_dict(data)
+                for path, data in (
                     self.get_item_data(item, children_stats[i])
+                    for i, item in enumerate(self.items)
                 )
-                for i, item in enumerate(self.items)
-            ],
+            },
         })
         return browsing_data
 

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -57,8 +57,11 @@ function provideStatsDefaults(stats) {
   }
 
   const newStats = assign({}, stats);
-  Object.keys(newStats.children).forEach((key) => {
-    const item = newStats.children[key];
+  newStats.children = [];
+  Object.keys(stats.children).forEach((key) => {
+    const item = stats.children[key];
+
+    item.pootle_path = key;
 
     item.treeitem_type = item.treeitem_type || 0;
     item.critical = item.critical || 0;
@@ -71,6 +74,8 @@ function provideStatsDefaults(stats) {
     const translated = item.translated || 0;
     item.progress = total > 0 ? translated / total : 1;
     item.incomplete = total - translated;
+
+    newStats.children.push(item);
   });
   return newStats;
 }

--- a/tests/views/disabled_project.py
+++ b/tests/views/disabled_project.py
@@ -40,9 +40,9 @@ def test_disabled_project_in_lang_browse_view(client, request_users):
     response = client.get(reverse("pootle-language-browse",
                                   kwargs={"language_code": "language0"}))
 
-    disabled_project_exists = "/language0/disabled_project0/" in [
-        item["pootle_path"]
-        for item in response.context['browsing_data']['children']
-    ]
+    disabled_project_exists = (
+        '/language0/disabled_project0/' in
+        response.context['browsing_data']['children']
+    )
 
     assert (user.is_superuser is disabled_project_exists)


### PR DESCRIPTION
Since the data is not sorted in the backend, a list doesn't make sense, hence
the switch to a dictionary.