### PR TITLE
Cleanup: remove obsolete tests

### DIFF
--- a/pytest_pootle/fixtures/views.py
+++ b/pytest_pootle/fixtures/views.py
@@ -158,20 +158,11 @@ GET_UNITS_TESTS = OrderedDict(
        "category": "critical"})))
 
 LANGUAGE_VIEW_TESTS = OrderedDict(
-    (("browse", {}),
-     ("translate", {}),
+    (("translate", {}),
      ("export", {})))
 
 PROJECT_VIEW_TESTS = OrderedDict(
-    (("browse", {}),
-     ("browse_directory",
-      {"dir_path": "subdir0/"}),
-     ("browse_store",
-      {"filename": "store0.po"}),
-     ("browse_directory_store",
-      {"dir_path": "subdir0/",
-       "filename": "store3.po"}),
-     ("translate", {}),
+    (("translate", {}),
      ("translate_directory",
       {"dir_path": "subdir0/"}),
      ("translate_store",
@@ -190,15 +181,7 @@ PROJECT_VIEW_TESTS = OrderedDict(
        "filename": "store3.po"})))
 
 TP_VIEW_TESTS = OrderedDict(
-    (("browse", {}),
-     ("browse_directory",
-      {"dir_path": "subdir0/"}),
-     ("browse_store",
-      {"filename": "store0.po"}),
-     ("browse_directory_store",
-      {"dir_path": "subdir0/",
-       "filename": "store3.po"}),
-     ("translate", {}),
+    (("translate", {}),
      ("translate_directory",
       {"dir_path": "subdir0/"}),
      ("translate_store",

--- a/tests/views/language.py
+++ b/tests/views/language.py
@@ -80,10 +80,6 @@ def _test_export_view(language, request, response, kwargs):
 @pytest.mark.django_db
 def test_views_language(language_views, settings):
     test_type, language, request, response, kwargs = language_views
-    if test_type == "browse":
-        pytest.xfail(
-            reason='this test needs to be replaced with snapshot-based one'
-        )
     if test_type == "translate":
         _test_translate_view(language, request, response, kwargs, settings)
     elif test_type == "export":

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -98,11 +98,7 @@ def _test_export_view(project, request, response, kwargs, settings):
 @pytest.mark.django_db
 def test_views_project(project_views, settings):
     test_type, project, request, response, kwargs = project_views
-    if test_type == "browse":
-        pytest.xfail(
-            reason='this test needs to be replaced with snapshot-based one'
-        )
-    elif test_type == "translate":
+    if test_type == "translate":
         _test_translate_view(project, request, response, kwargs, settings)
     if test_type == "export":
         _test_export_view(project, request, response, kwargs, settings)

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -87,11 +87,7 @@ def _test_export_view(tp, request, response, kwargs, settings):
 @pytest.mark.django_db
 def test_views_tp(tp_views, settings):
     test_type, tp, request, response, kwargs = tp_views
-    if test_type == "browse":
-        pytest.xfail(
-            reason='this test needs to be replaced with snapshot-based one'
-        )
-    elif test_type == "translate":
+    if test_type == "translate":
         _test_translate_view(tp, request, response, kwargs, settings)
     else:
         _test_export_view(tp, request, response, kwargs, settings)


### PR DESCRIPTION
These browse view tests are now tested using snapshots.