### PR TITLE
Tests: fix login for browse views

### DIFF
--- a/tests/data/snapshots/test_browse/admin/_language0_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_language0_.context.json
@@ -7,6 +7,11 @@
   "browser_extends": "languages/base.html",
   "browsing_data": {
     "children": {
+      "/language0/disabled_project0/": {
+        "is_disabled": true,
+        "title": "Disabled Project 0",
+        "treeitem_type": 2
+      },
       "/language0/project0/": {
         "title": "Project 0",
         "treeitem_type": 2
@@ -218,7 +223,7 @@
     }
   ],
   "export_url": "/language0/export-view/",
-  "has_admin_access": false,
+  "has_admin_access": true,
   "has_sidebar": true,
   "is_disabled": false,
   "is_sidebar_open": true,
@@ -295,5 +300,5 @@
   "url_action_fixcritical": "/language0/translate/#filter=checks&category=critical",
   "url_action_review": "/language0/translate/#filter=suggestions",
   "url_action_view_all": "/language0/translate/#filter=all",
-  "user": "nobody"
+  "user": "admin"
 }

--- a/tests/data/snapshots/test_browse/admin/_language0_project0_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_language0_project0_.context.json
@@ -224,7 +224,7 @@
     }
   ],
   "export_url": "/language0/project0/export-view/",
-  "has_admin_access": false,
+  "has_admin_access": true,
   "has_sidebar": true,
   "is_disabled": false,
   "is_sidebar_open": true,
@@ -302,5 +302,5 @@
   "url_action_fixcritical": "/language0/project0/translate/#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/#filter=all",
-  "user": "nobody"
+  "user": "admin"
 }

--- a/tests/data/snapshots/test_browse/admin/_language0_project0_store0.po.context.json
+++ b/tests/data/snapshots/test_browse/admin/_language0_project0_store0.po.context.json
@@ -207,7 +207,7 @@
     }
   ],
   "export_url": "/language0/project0/export-view/store0.po",
-  "has_admin_access": false,
+  "has_admin_access": true,
   "has_sidebar": true,
   "is_disabled": false,
   "is_sidebar_open": true,
@@ -289,5 +289,5 @@
   "url_action_fixcritical": "/language0/project0/translate/store0.po#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/store0.po#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/store0.po#filter=all",
-  "user": "nobody"
+  "user": "admin"
 }

--- a/tests/data/snapshots/test_browse/admin/_language0_project0_subdir0_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_language0_project0_subdir0_.context.json
@@ -218,7 +218,7 @@
     }
   ],
   "export_url": "/language0/project0/export-view/subdir0/",
-  "has_admin_access": false,
+  "has_admin_access": true,
   "has_sidebar": true,
   "is_disabled": false,
   "is_sidebar_open": true,
@@ -299,5 +299,5 @@
   "url_action_fixcritical": "/language0/project0/translate/subdir0/#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/subdir0/#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/subdir0/#filter=all",
-  "user": "nobody"
+  "user": "admin"
 }

--- a/tests/data/snapshots/test_browse/admin/_language0_project0_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_browse/admin/_language0_project0_subdir0_store4.po.context.json
@@ -207,7 +207,7 @@
     }
   ],
   "export_url": "/language0/project0/export-view/subdir0/store4.po",
-  "has_admin_access": false,
+  "has_admin_access": true,
   "has_sidebar": true,
   "is_disabled": false,
   "is_sidebar_open": true,
@@ -290,5 +290,5 @@
   "url_action_fixcritical": "/language0/project0/translate/subdir0/store4.po#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/subdir0/store4.po#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/subdir0/store4.po#filter=all",
-  "user": "nobody"
+  "user": "admin"
 }

--- a/tests/data/snapshots/test_browse/admin/_projects_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_projects_.context.json
@@ -3,6 +3,11 @@
   "browser_extends": "projects/all/base.html",
   "browsing_data": {
     "children": {
+      "/projects/disabled_project0/": {
+        "is_disabled": true,
+        "title": "Disabled Project 0",
+        "treeitem_type": 2
+      },
       "/projects/project0/": {
         "title": "Project 0",
         "treeitem_type": 2
@@ -17,8 +22,8 @@
       }
     }
   },
-  "can_translate": false,
-  "can_translate_stats": false,
+  "can_translate": true,
+  "can_translate_stats": true,
   "checks": [
     {
       "code": "dollar_sign_closure_placeholders",
@@ -214,8 +219,8 @@
     }
   ],
   "export_url": "/projects/export-view/",
-  "has_admin_access": false,
-  "is_disabled": true,
+  "has_admin_access": true,
+  "is_disabled": false,
   "language": null,
   "nav": "projects/all/_nav.html",
   "object": "/projects/",
@@ -225,7 +230,7 @@
   "resource_path": "",
   "resource_path_parts": [],
   "search_action": "/projects/translate/",
-  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search unavailable\" readonly=\"readonly\" size=\"15\" title=\"\" type=\"text\" disabled /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
   "stats_refresh_attempts_count": 2,
   "top_scorers": {
     "items": [
@@ -282,9 +287,9 @@
       "url": "/projects/translate/#filter=untranslated"
     }
   ],
-  "url_action_continue": null,
-  "url_action_fixcritical": null,
-  "url_action_review": null,
-  "url_action_view_all": null,
-  "user": "nobody"
+  "url_action_continue": "/projects/translate/#filter=incomplete",
+  "url_action_fixcritical": "/projects/translate/#filter=checks&category=critical",
+  "url_action_review": "/projects/translate/#filter=suggestions",
+  "url_action_view_all": "/projects/translate/#filter=all",
+  "user": "admin"
 }

--- a/tests/data/snapshots/test_browse/admin/_projects_project0_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_projects_project0_.context.json
@@ -18,7 +18,7 @@
     }
   },
   "can_translate": true,
-  "can_translate_stats": false,
+  "can_translate_stats": true,
   "checks": [
     {
       "code": "dollar_sign_closure_placeholders",
@@ -214,9 +214,9 @@
     }
   ],
   "export_url": "/projects/project0/export-view/",
-  "has_admin_access": false,
+  "has_admin_access": true,
   "has_sidebar": true,
-  "is_disabled": true,
+  "is_disabled": false,
   "is_sidebar_open": true,
   "language": null,
   "nav": "projects/_nav.html",
@@ -227,7 +227,7 @@
   "resource_path": "",
   "resource_path_parts": [],
   "search_action": "/projects/project0/translate/",
-  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search unavailable\" readonly=\"readonly\" size=\"15\" title=\"\" type=\"text\" disabled /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
+  "search_form": "<tr><th><label for=\"id_search\">Search:</label></th><td><input id=\"id_search\" name=\"search\" placeholder=\"Search\" size=\"15\" title=\"Search (Ctrl+Shift+S)&lt;br/&gt;Type and press Enter to search\" type=\"text\" /></td></tr>\n<tr><th><label for=\"id_soptions_0\">Soptions:</label></th><td><ul id=\"id_soptions\"><li><label for=\"id_soptions_0\"><input id=\"id_soptions_0\" name=\"soptions\" type=\"checkbox\" value=\"exact\" /> Exact Match</label></li></ul></td></tr>\n<tr><th><label for=\"id_sfields_0\">Sfields:</label></th><td><ul id=\"id_sfields\"><li><label for=\"id_sfields_0\"><input checked=\"checked\" id=\"id_sfields_0\" name=\"sfields\" type=\"checkbox\" value=\"source\" /> Source Text</label></li>\n<li><label for=\"id_sfields_1\"><input checked=\"checked\" id=\"id_sfields_1\" name=\"sfields\" type=\"checkbox\" value=\"target\" /> Target Text</label></li>\n<li><label for=\"id_sfields_2\"><input id=\"id_sfields_2\" name=\"sfields\" type=\"checkbox\" value=\"notes\" /> Comments</label></li>\n<li><label for=\"id_sfields_3\"><input id=\"id_sfields_3\" name=\"sfields\" type=\"checkbox\" value=\"locations\" /> Locations</label></li></ul></td></tr>",
   "stats_refresh_attempts_count": 2,
   "top_scorers": {
     "items": [
@@ -284,9 +284,9 @@
       "url": "/projects/project0/translate/#filter=untranslated"
     }
   ],
-  "url_action_continue": null,
-  "url_action_fixcritical": null,
-  "url_action_review": null,
-  "url_action_view_all": null,
-  "user": "nobody"
+  "url_action_continue": "/projects/project0/translate/#filter=incomplete",
+  "url_action_fixcritical": "/projects/project0/translate/#filter=checks&category=critical",
+  "url_action_review": "/projects/project0/translate/#filter=suggestions",
+  "url_action_view_all": "/projects/project0/translate/#filter=all",
+  "user": "admin"
 }

--- a/tests/data/snapshots/test_browse/member/_language0_.context.json
+++ b/tests/data/snapshots/test_browse/member/_language0_.context.json
@@ -295,5 +295,5 @@
   "url_action_fixcritical": "/language0/translate/#filter=checks&category=critical",
   "url_action_review": "/language0/translate/#filter=suggestions",
   "url_action_view_all": "/language0/translate/#filter=all",
-  "user": "nobody"
+  "user": "member"
 }

--- a/tests/data/snapshots/test_browse/member/_language0_project0_.context.json
+++ b/tests/data/snapshots/test_browse/member/_language0_project0_.context.json
@@ -302,5 +302,5 @@
   "url_action_fixcritical": "/language0/project0/translate/#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/#filter=all",
-  "user": "nobody"
+  "user": "member"
 }

--- a/tests/data/snapshots/test_browse/member/_language0_project0_store0.po.context.json
+++ b/tests/data/snapshots/test_browse/member/_language0_project0_store0.po.context.json
@@ -289,5 +289,5 @@
   "url_action_fixcritical": "/language0/project0/translate/store0.po#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/store0.po#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/store0.po#filter=all",
-  "user": "nobody"
+  "user": "member"
 }

--- a/tests/data/snapshots/test_browse/member/_language0_project0_subdir0_.context.json
+++ b/tests/data/snapshots/test_browse/member/_language0_project0_subdir0_.context.json
@@ -299,5 +299,5 @@
   "url_action_fixcritical": "/language0/project0/translate/subdir0/#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/subdir0/#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/subdir0/#filter=all",
-  "user": "nobody"
+  "user": "member"
 }

--- a/tests/data/snapshots/test_browse/member/_language0_project0_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_browse/member/_language0_project0_subdir0_store4.po.context.json
@@ -290,5 +290,5 @@
   "url_action_fixcritical": "/language0/project0/translate/subdir0/store4.po#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/subdir0/store4.po#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/subdir0/store4.po#filter=all",
-  "user": "nobody"
+  "user": "member"
 }

--- a/tests/data/snapshots/test_browse/member/_projects_.context.json
+++ b/tests/data/snapshots/test_browse/member/_projects_.context.json
@@ -286,5 +286,5 @@
   "url_action_fixcritical": null,
   "url_action_review": null,
   "url_action_view_all": null,
-  "user": "nobody"
+  "user": "member"
 }

--- a/tests/data/snapshots/test_browse/member/_projects_project0_.context.json
+++ b/tests/data/snapshots/test_browse/member/_projects_project0_.context.json
@@ -288,5 +288,5 @@
   "url_action_fixcritical": null,
   "url_action_review": null,
   "url_action_view_all": null,
-  "user": "nobody"
+  "user": "member"
 }

--- a/tests/data/snapshots/test_browse/member2/_language0_.context.json
+++ b/tests/data/snapshots/test_browse/member2/_language0_.context.json
@@ -295,5 +295,5 @@
   "url_action_fixcritical": "/language0/translate/#filter=checks&category=critical",
   "url_action_review": "/language0/translate/#filter=suggestions",
   "url_action_view_all": "/language0/translate/#filter=all",
-  "user": "nobody"
+  "user": "member2"
 }

--- a/tests/data/snapshots/test_browse/member2/_language0_project0_.context.json
+++ b/tests/data/snapshots/test_browse/member2/_language0_project0_.context.json
@@ -302,5 +302,5 @@
   "url_action_fixcritical": "/language0/project0/translate/#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/#filter=all",
-  "user": "nobody"
+  "user": "member2"
 }

--- a/tests/data/snapshots/test_browse/member2/_language0_project0_store0.po.context.json
+++ b/tests/data/snapshots/test_browse/member2/_language0_project0_store0.po.context.json
@@ -289,5 +289,5 @@
   "url_action_fixcritical": "/language0/project0/translate/store0.po#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/store0.po#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/store0.po#filter=all",
-  "user": "nobody"
+  "user": "member2"
 }

--- a/tests/data/snapshots/test_browse/member2/_language0_project0_subdir0_.context.json
+++ b/tests/data/snapshots/test_browse/member2/_language0_project0_subdir0_.context.json
@@ -299,5 +299,5 @@
   "url_action_fixcritical": "/language0/project0/translate/subdir0/#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/subdir0/#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/subdir0/#filter=all",
-  "user": "nobody"
+  "user": "member2"
 }

--- a/tests/data/snapshots/test_browse/member2/_language0_project0_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_browse/member2/_language0_project0_subdir0_store4.po.context.json
@@ -290,5 +290,5 @@
   "url_action_fixcritical": "/language0/project0/translate/subdir0/store4.po#filter=checks&category=critical",
   "url_action_review": "/language0/project0/translate/subdir0/store4.po#filter=suggestions",
   "url_action_view_all": "/language0/project0/translate/subdir0/store4.po#filter=all",
-  "user": "nobody"
+  "user": "member2"
 }

--- a/tests/data/snapshots/test_browse/member2/_projects_.context.json
+++ b/tests/data/snapshots/test_browse/member2/_projects_.context.json
@@ -286,5 +286,5 @@
   "url_action_fixcritical": null,
   "url_action_review": null,
   "url_action_view_all": null,
-  "user": "nobody"
+  "user": "member2"
 }

--- a/tests/data/snapshots/test_browse/member2/_projects_project0_.context.json
+++ b/tests/data/snapshots/test_browse/member2/_projects_project0_.context.json
@@ -288,5 +288,5 @@
   "url_action_fixcritical": null,
   "url_action_review": null,
   "url_action_view_all": null,
-  "user": "nobody"
+  "user": "member2"
 }

--- a/tests/views/browse.py
+++ b/tests/views/browse.py
@@ -30,7 +30,7 @@ def test_browse(client, request_users, test_name, flush_redis,
         as_dir(test_name), as_dir(user.username), url_name(url)
     ]):
         if not user.is_anonymous():
-            client.login(username=user.username, password=user.password)
+            client.force_login(user)
         response = client.get(url)
         assert response.status_code == 200
 


### PR DESCRIPTION
It turns out the login function wasn't succeeding (`client.login()` doesn't give
any hint of that), and therefore all tests were being run as anonymous.

Note this doesn't only affect snapshot tests, and older tests also suffer from
this when trying to log in registered members: in the fixture they have no
password set, then an unusable password is set by the environment setup,
therefore any attempts to login using the empty string password fail and the
view code will be run as anonymous.

The simple and effective solution is to use the test client's `force_login()`
method, which is available since Django 1.9.