### PR TITLE
Snapshot: support cleaning `RequestContext`s

### DIFF
--- a/pootle/core/models/snapshot.py
+++ b/pootle/core/models/snapshot.py
@@ -8,6 +8,7 @@
 
 import os
 
+from django.template import RequestContext
 from django.test.utils import ContextList
 from django.utils.functional import cached_property
 
@@ -65,9 +66,11 @@ class Snapshot(object):
 
     def clean(self, data):
         """Cleans up `data` before using it as a snapshot reference."""
+        if isinstance(data, RequestContext):
+            return self.clean(data.flatten())
         # XXX: maybe we can do something smarter than blacklisting when we
         # have a `ContextList`?
-        if isinstance(data, dict) or isinstance(data, ContextList):
+        elif isinstance(data, dict) or isinstance(data, ContextList):
             return {
                 key: self.clean(data[key]) for key in data.keys()
                 if key not in BLACKLISTED_KEYS

--- a/tests/models/snapshot.py
+++ b/tests/models/snapshot.py
@@ -8,7 +8,7 @@
 
 import pytest
 
-from django.template import Context
+from django.template import Context, RequestContext
 from django.test.utils import ContextList
 
 from pootle.core.models.snapshot import Snapshot, SnapshotStack
@@ -63,6 +63,8 @@ def test_snapshot_reference(tmpdir):
     (ContextList([Context({'block': True})]), {}),
     (ContextList([Context({'block': True}), Context({'foo': 'bar'})]),
      {'foo': 'bar'}),
+
+    (RequestContext(None, {'foo': 'bar'}), {'foo': 'bar'}),
 ])
 def test_snapshot_clean(input, clean_output):
     """Tests the cleanup of snapshot contexts."""


### PR DESCRIPTION
Some response contexts might provide a `RequestContext`, so we also need to
account for that.