### PR TITLE
Snapshots: make paths and newlines work properly on any platform

### DIFF
--- a/pootle/core/models/snapshot.py
+++ b/pootle/core/models/snapshot.py
@@ -47,12 +47,13 @@ class Snapshot(object):
 
     @cached_property
     def filepath(self):
-        base_dir = self.data_dir
+        base_dir = os.path.normpath(self.data_dir)
         filepath = os.path.abspath(os.path.join(base_dir, self.filename))
 
         if os.path.commonprefix([filepath, base_dir]) != base_dir:
             raise ValueError(
-                'The requested file path is out of the data directory.'
+                'The requested file path "%s" is out '
+                'of the data directory "%s".' % (filepath, self.data_dir)
             )
         return filepath
 

--- a/pootle/core/models/snapshot.py
+++ b/pootle/core/models/snapshot.py
@@ -91,7 +91,8 @@ class Snapshot(object):
         except OSError:
             pass
 
-        with open(self.filepath, 'w') as outfile:
+        # use binary mode not to convert \n to OS-specific newlines;
+        with open(self.filepath, 'wb') as outfile:
             outfile.write(ctx_data)
 
     def assert_matches(self, ctx_data):

--- a/tests/models/snapshot.py
+++ b/tests/models/snapshot.py
@@ -34,9 +34,10 @@ def test_snapshot_filepath(tmpdir):
     snapshot.filepath == reference_file
 
 
-def test_snapshot_reference_non_existant():
+def test_snapshot_reference_non_existant(tmpdir):
     """Tests snapshots for non-existant references."""
-    snapshot = Snapshot('bogus')
+    reference_file = tmpdir.join('non-existant')
+    snapshot = Snapshot('non-existant', data_dir=reference_file.dirname)
     assert snapshot.reference is None
 
 


### PR DESCRIPTION
Windows uses back-slash as a canonical path separator, whereas we use forward slashes to denote snapshot paths.

Without normalization, snapshot tests would fail on Windows as `filepath` and `base_dir` would use different delimiters, and 'The requested file path is out of the data directory.' exception would be raised.

Also, when saving snapshots, we must always force Unix newlines regardless of the platform.