### PR TITLE
Test: fixes around project fixture

### DIFF
--- a/pytest_pootle/fixtures/models/project.py
+++ b/pytest_pootle/fixtures/models/project.py
@@ -85,7 +85,8 @@ def project0_directory(po_directory, project0):
 
 
 @pytest.fixture
-def project0_nongnu(project0_directory, project0, settings):
+def project0_disk(project0_directory, project0, settings):
+    """`project0` fixture but with on-disk directories and TPs."""
     project0.save()
     project_dir = os.path.join(
         settings.POOTLE_TRANSLATION_DIRECTORY, project0.code)

--- a/pytest_pootle/fixtures/models/project.py
+++ b/pytest_pootle/fixtures/models/project.py
@@ -88,10 +88,6 @@ def project0_directory(po_directory, project0):
 def project0_disk(project0_directory, project0, settings):
     """`project0` fixture but with on-disk directories and TPs."""
     project0.save()
-    project_dir = os.path.join(
-        settings.POOTLE_TRANSLATION_DIRECTORY, project0.code)
-    if not os.path.exists(project_dir):
-        os.makedirs(project_dir)
     for tp in project0.translationproject_set.all():
         tp.save()
     return project0

--- a/pytest_pootle/fixtures/models/store.py
+++ b/pytest_pootle/fixtures/models/store.py
@@ -566,14 +566,15 @@ def ordered_po(test_fs, tp0):
 
 
 @pytest.fixture
-def numbered_po(test_fs, project0):
+def numbered_po(test_fs, project0_disk):
     """Create a store with numbered units."""
     from pytest_pootle.factories import (
         LanguageDBFactory, StoreDBFactory, TranslationProjectFactory)
 
     tp = TranslationProjectFactory(
-        project=project0,
-        language=LanguageDBFactory())
+        project=project0_disk,
+        language=LanguageDBFactory()
+    )
     store = StoreDBFactory(
         name="numbered.po",
         translation_project=tp,

--- a/tests/commands/changed_languages.py
+++ b/tests/commands/changed_languages.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -31,7 +32,7 @@ def test_changed_languages_noargs(capfd):
 
 @pytest.mark.cmd
 @pytest.mark.django_db
-def test_changed_languages_noargs_nochanges(capfd, project0_nongnu, store0):
+def test_changed_languages_noargs_nochanges(capfd, project0_disk, store0):
     """Get changed languages since last sync."""
     unit = store0.units.first()
     unit.target = "CHANGED"
@@ -51,7 +52,7 @@ def test_changed_languages_noargs_nochanges(capfd, project0_nongnu, store0):
 
 @pytest.mark.cmd
 @pytest.mark.django_db
-def test_changed_languages_since_revision(capfd, project0_nongnu, tp0):
+def test_changed_languages_since_revision(capfd, project0_disk, tp0):
     """Changed languages since a given revision"""
     # Everything
     for store in tp0.stores.all():

--- a/tests/commands/update_stores.py
+++ b/tests/commands/update_stores.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -13,7 +14,7 @@ from django.core.management import call_command
 
 @pytest.mark.cmd
 @pytest.mark.django_db
-def test_update_stores_noargs(capfd, project0_nongnu, project1, language1):
+def test_update_stores_noargs(capfd, project0_disk, project1, language1):
     """Site wide update_stores"""
     # speed up test by deleting objects
     project1.delete()

--- a/tests/core/decorators.py
+++ b/tests/core/decorators.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -60,11 +61,8 @@ def test_get_path_obj(rf, po_directory, default, tp0):
 
 
 @pytest.mark.django_db
-def test_get_path_obj_disabled(rf, default, admin,
-                               project0_nongnu,
-                               tp0,
-                               project_foo,
-                               en_tutorial_obsolete,
+def test_get_path_obj_disabled(rf, default, admin, project0_disk, tp0,
+                               project_foo, en_tutorial_obsolete,
                                tutorial_disabled):
     """Ensure the correct path object is retrieved when projects are
     disabled (#3451) or translation projects are obsolete (#3682).

--- a/tests/models/directory.py
+++ b/tests/models/directory.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -41,7 +42,7 @@ def test_directory_create_bad(root):
 
 
 @pytest.mark.django_db
-def test_delete_mark_obsolete_resurrect_sync(project0_nongnu, subdir0):
+def test_delete_mark_obsolete_resurrect_sync(project0_disk, subdir0):
     """Tests that the in-DB Directory are marked as obsolete
     after the on-disk file ceased to exist and that the on-disk file and
     directory are recovered after syncing.
@@ -96,7 +97,7 @@ def test_delete_mark_obsolete_resurrect_sync(project0_nongnu, subdir0):
 
 
 @pytest.mark.django_db
-def test_scan_empty_project_obsolete_dirs(project0_nongnu, store0):
+def test_scan_empty_project_obsolete_dirs(project0_disk, store0):
     """Tests that the in-DB Directories are marked as obsolete
     if the on-disk directories are empty.
     """

--- a/tests/models/revision.py
+++ b/tests/models/revision.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -15,7 +16,7 @@ from .unit import _update_translation
 
 
 @pytest.mark.django_db
-def test_max_revision(revision, project0_nongnu, store0):
+def test_max_revision(revision, project0_disk, store0):
     """Tests `max_revision()` gets the latest revision."""
     store0.sync()
 

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -44,17 +44,16 @@ def _store_as_string(store):
 
 
 @pytest.mark.django_db
-def test_delete_mark_obsolete(project0_disk, project0, store0):
+def test_delete_mark_obsolete(project0_disk, store0):
     """Tests that the in-DB Store and Directory are marked as obsolete
     after the on-disk file ceased to exist.
 
     Refs. #269.
     """
     tp = TranslationProjectFactory(
-        project=project0, language=LanguageDBFactory())
-    store = StoreDBFactory(
-        translation_project=tp,
-        parent=tp.directory)
+        project=project0_disk, language=LanguageDBFactory()
+    )
+    store = StoreDBFactory(translation_project=tp, parent=tp.directory)
 
     store.update(store.deserialize(store0.serialize()))
     store.sync()
@@ -76,16 +75,15 @@ def test_delete_mark_obsolete(project0_disk, project0, store0):
 
 
 @pytest.mark.django_db
-def test_sync(project0_disk, project0, store0):
+def test_sync(project0_disk, store0):
     """Tests that the new on-disk file is created after sync for existing
     in-DB Store if the corresponding on-disk file ceased to exist.
     """
-
     tp = TranslationProjectFactory(
-        project=project0, language=LanguageDBFactory())
-    store = StoreDBFactory(
-        translation_project=tp,
-        parent=tp.directory)
+        project=project0_disk, language=LanguageDBFactory()
+    )
+    store = StoreDBFactory(translation_project=tp, parent=tp.directory)
+
     store.update(store.deserialize(store0.serialize()))
     assert not store.file.exists()
     store.sync()

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -44,7 +44,7 @@ def _store_as_string(store):
 
 
 @pytest.mark.django_db
-def test_delete_mark_obsolete(project0_nongnu, project0, store0):
+def test_delete_mark_obsolete(project0_disk, project0, store0):
     """Tests that the in-DB Store and Directory are marked as obsolete
     after the on-disk file ceased to exist.
 
@@ -76,7 +76,7 @@ def test_delete_mark_obsolete(project0_nongnu, project0, store0):
 
 
 @pytest.mark.django_db
-def test_sync(project0_nongnu, project0, store0):
+def test_sync(project0_disk, project0, store0):
     """Tests that the new on-disk file is created after sync for existing
     in-DB Store if the corresponding on-disk file ceased to exist.
     """
@@ -132,7 +132,7 @@ def test_update_with_non_ascii(store0, test_fs):
 
 
 @pytest.mark.django_db
-def test_update_unit_order(project0_nongnu, ordered_po, ordered_update_ttk):
+def test_update_unit_order(project0_disk, ordered_po, ordered_update_ttk):
     """Tests unit order after a specific update.
     """
 
@@ -161,7 +161,7 @@ def test_update_unit_order(project0_nongnu, ordered_po, ordered_update_ttk):
 
 
 @pytest.mark.django_db
-def test_update_save_changed_units(project0_nongnu, store0):
+def test_update_save_changed_units(project0_disk, store0):
     """Tests that any update saves changed units only.
     """
     store = store0
@@ -185,7 +185,7 @@ def test_update_save_changed_units(project0_nongnu, store0):
 
 
 @pytest.mark.django_db
-def test_update_set_last_sync_revision(project0_nongnu, tp0, store0, test_fs):
+def test_update_set_last_sync_revision(project0_disk, tp0, store0, test_fs):
     """Tests setting last_sync_revision after store creation.
     """
     unit = store0.units.first()

--- a/tests/models/unit.py
+++ b/tests/models/unit.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -48,7 +49,7 @@ def _update_translation(store, item, new_values, sync=True):
 
 
 @pytest.mark.django_db
-def test_getorig(project0_nongnu, store0):
+def test_getorig(project0_disk, store0):
     """Tests that the in-DB Store and on-disk Store match by checking that
     units match in order.
     """
@@ -59,7 +60,7 @@ def test_getorig(project0_nongnu, store0):
 
 
 @pytest.mark.django_db
-def test_convert(project0_nongnu, store0):
+def test_convert(project0_disk, store0):
     """Tests that in-DB and on-disk units match after format conversion."""
     store0.sync()
     for db_unit in store0.units.iterator():
@@ -70,7 +71,7 @@ def test_convert(project0_nongnu, store0):
 
 
 @pytest.mark.django_db
-def test_update_target(project0_nongnu, store0):
+def test_update_target(project0_disk, store0):
     """Tests that target changes are properly sync'ed to disk."""
     db_unit = _update_translation(store0, 0, {'target': u'samaka'})
     store0.sync()
@@ -137,7 +138,7 @@ def test_update_plural_target_dict(af_tutorial_po):
 
 
 @pytest.mark.django_db
-def test_update_fuzzy(project0_nongnu, store0):
+def test_update_fuzzy(project0_disk, store0):
     """Tests fuzzy state changes are stored and sync'ed."""
     db_unit = _update_translation(
         store0, 0,
@@ -161,7 +162,7 @@ def test_update_fuzzy(project0_nongnu, store0):
 
 
 @pytest.mark.django_db
-def test_update_comment(project0_nongnu, store0):
+def test_update_comment(project0_disk, store0):
     """Tests translator comments are stored and sync'ed."""
     db_unit = _update_translation(
         store0, 0,

--- a/tests/views/get_edit_unit.py
+++ b/tests/views/get_edit_unit.py
@@ -17,7 +17,7 @@ from pootle_store.views import get_alt_src_langs
 
 
 @pytest.mark.django_db
-def test_get_edit_unit(project0_nongnu, get_edit_unit, client,
+def test_get_edit_unit(project0_disk, get_edit_unit, client,
                        request_users, settings):
     user = request_users["user"]
     if user.username != "nobody":


### PR DESCRIPTION
This PR cleans up and fixes some inconsistencies around the old `project0_nongnu` fixture. Each commit contains the specific details.