### PR TITLE
Export view: limit access as we do for translate views

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ v0.1.4 (in development)
 -----------------------
 
 * Fixed browser table sorting for total/untranslated columns (#120).
+* Restricted access to project-wide export views (#142).
 * Quality checks now default to a site-wide checker (#119). In the future,
   project-specific checkers will be disallowed.
 * Implemented view testing via snapshots (#45). More tests will need to be

--- a/pootle/apps/pootle_project/views.py
+++ b/pootle/apps/pootle_project/views.py
@@ -143,6 +143,7 @@ class ProjectTranslateView(ProjectMixin, PootleTranslateView):
 
 
 class ProjectExportView(ProjectMixin, PootleExportView):
+    required_permission = 'administrate'
     source_language = "en"
 
 
@@ -220,4 +221,5 @@ class ProjectsTranslateView(ProjectsMixin, PootleTranslateView):
 
 
 class ProjectsExportView(ProjectsMixin, PootleExportView):
+    required_permission = 'administrate'
     source_language = "en"

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -26,6 +26,10 @@ from pootle_store.models import Unit
 
 
 def _test_export_view(project, request, response, kwargs, settings):
+    if not request.user.is_superuser:
+        assert response.status_code == 403
+        return
+
     ctx = response.context
     kwargs["project_code"] = project.code
     filter_name, filter_extra = get_filter_name(request.GET)
@@ -104,6 +108,11 @@ def test_view_projects_export(client):
     response = client.get(reverse("pootle-projects-export"))
     ctx = response.context
     request = response.wsgi_request
+
+    if not request.user.is_superuser:
+        assert response.status_code == 403
+        return
+
     filter_name, filter_extra = get_filter_name(request.GET)
     form_data = request.GET.copy()
     form_data["path"] = request.path.replace("export-view/", "")


### PR DESCRIPTION
Even if the access to these URLs is not exhibited anywhere in the UI, they are
still open to anyone with the major risk that it carries for the server. With
this change we limit the access to such views the same way we do for translate
views.