### PR TITLE
Export view: limit result set to a sane amount

### DIFF
--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -456,16 +456,6 @@ Translation environment configuration settings.
      recalculate the associated wordcounts.
 
 
-.. setting:: POOTLE_EXPORT_VIEW_LIMIT
-
-``POOTLE_EXPORT_VIEW_LIMIT``
-  Default: ``10000``
-
-  .. versionadded:: 2.8
-
-  The maximum number of units that will be exported in export views.
-
-
 .. _settings#deprecated:
 
 Deprecated Settings

--- a/pootle/core/views/export.py
+++ b/pootle/core/views/export.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
 from itertools import groupby
 
-from django.conf import settings
 from django.forms import ValidationError
 from django.http import Http404
 
@@ -18,6 +18,10 @@ from pootle_store.forms import UnitExportForm
 from pootle_store.models import Unit
 
 from .base import PootleDetailView
+
+
+# Limit export view results to this amount of units
+UNITS_LIMIT = 500
 
 
 class PootleExportView(PootleDetailView):
@@ -45,11 +49,12 @@ class PootleExportView(PootleDetailView):
 
         units_qs = units_qs.select_related('store')
 
-        if total > settings.POOTLE_EXPORT_VIEW_LIMIT:
-            units_qs = units_qs[:settings.POOTLE_EXPORT_VIEW_LIMIT]
-            ctx.update(
-                {'unit_total_count': total,
-                 'displayed_unit_count': settings.POOTLE_EXPORT_VIEW_LIMIT})
+        if total > UNITS_LIMIT:
+            units_qs = units_qs[:UNITS_LIMIT]
+            ctx.update({
+                'unit_total_count': total,
+                'displayed_unit_count': UNITS_LIMIT,
+            })
 
         unit_groups = [
             (path, list(units))

--- a/pootle/settings/50-project.conf
+++ b/pootle/settings/50-project.conf
@@ -117,8 +117,6 @@ AUTH_USER_MODEL = 'accounts.User'
 
 COMMENTS_APP = "pootle_comment"
 
-POOTLE_EXPORT_VIEW_LIMIT = 10000
-
 # Number of silent attempts to refresh stale statistics data before a banner
 # pops up telling you that the statistics are outdated.
 # The banner will appear immediately if you set it to 0 and open a browsing page

--- a/tests/views/project.py
+++ b/tests/views/project.py
@@ -19,6 +19,7 @@ from pootle_app.models.permissions import check_permission
 from pootle.core.delegate import search_backend
 from pootle.core.helpers import get_filter_name
 from pootle.core.url_helpers import get_previous_url
+from pootle.core.views.export import UNITS_LIMIT
 from pootle_misc.checks import get_qualitycheck_schema
 from pootle_misc.forms import make_search_form
 from pootle_store.forms import UnitExportForm
@@ -42,11 +43,11 @@ def _test_export_view(project, request, response, kwargs, settings):
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     assertions = {}
-    if total > settings.POOTLE_EXPORT_VIEW_LIMIT:
-        units_qs = units_qs[:settings.POOTLE_EXPORT_VIEW_LIMIT]
+    if total > UNITS_LIMIT:
+        units_qs = units_qs[:UNITS_LIMIT]
         assertions.update(
             {'unit_total_count': total,
-             'displayed_unit_count': settings.POOTLE_EXPORT_VIEW_LIMIT})
+             'displayed_unit_count': UNITS_LIMIT})
     unit_groups = [
         (path, list(units))
         for path, units

--- a/tests/views/tp.py
+++ b/tests/views/tp.py
@@ -15,6 +15,7 @@ from pytest_pootle.suite import view_context_test
 
 from pootle.core.delegate import search_backend
 from pootle.core.helpers import get_filter_name
+from pootle.core.views.export import UNITS_LIMIT
 from pootle_store.forms import UnitExportForm
 from pootle_store.models import Unit
 
@@ -31,11 +32,11 @@ def _test_export_view(tp, request, response, kwargs, settings):
         request.user, **search_form.cleaned_data).search()
     units_qs = units_qs.select_related('store')
     assertions = {}
-    if total > settings.POOTLE_EXPORT_VIEW_LIMIT:
-        units_qs = units_qs[:settings.POOTLE_EXPORT_VIEW_LIMIT]
+    if total > UNITS_LIMIT:
+        units_qs = units_qs[:UNITS_LIMIT]
         assertions.update(
             {'unit_total_count': total,
-             'displayed_unit_count': settings.POOTLE_EXPORT_VIEW_LIMIT})
+             'displayed_unit_count': UNITS_LIMIT})
     unit_groups = [
         (path, list(units))
         for path, units


### PR DESCRIPTION
It also removes the setting as this is not something deployments should be
concerned and thinking about.