### PR TITLE
Optimize terminology access

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Zing Changelog
 v0.1.5 (in development)
 -----------------------
 
+* Optimized terminology access (#144).
+
 
 v0.1.4 (2016-12-19)
 -------------------

--- a/docs/features/terminology.rst
+++ b/docs/features/terminology.rst
@@ -6,10 +6,7 @@ Terminology
 Pootle can help translators with terminology. Terminology can be specified to
 be global per language, and can be overridden per project for each language. A
 project called *terminology* (with any full name) can contain any files that
-will be used for terminology matching. Alternatively a file with the name
-*pootle-terminology.po* (in a PO project) can be put in the directory of the
-project, in which case the global one (in the terminology project) will not be
-used. Matching is done in real time.
+will be used for terminology matching. Matching is done in real time.
 
 Ideally, the source term should be the shortest, simplest form of a word.
 Therefore *cat*, *dog*, *house* are good, but *cats*, *dogged* and *housing*

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1079,6 +1079,7 @@ class Unit(models.Model, base.TranslationUnit):
         # log user action
         self.save()
 
+    @cached_property
     def get_terminology(self):
         """get terminology suggestions"""
         matcher = self.store.translation_project.gettermmatcher()

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -266,6 +266,15 @@ class Unit(models.Model, base.TranslationUnit):
         self.target_f = value
         self._target_updated = True
 
+    @cached_property
+    def terminology(self):
+        """Retrieves terminology suggestions."""
+        matcher = self.store.translation_project.gettermmatcher()
+        if matcher is None:
+            return []
+
+        return matcher.matches(self.source)
+
     # # # # # # # # # # # # # Class & static methods # # # # # # # # # # # # #
 
     @classmethod
@@ -1079,15 +1088,6 @@ class Unit(models.Model, base.TranslationUnit):
         # log user action
         self.save()
 
-    @cached_property
-    def get_terminology(self):
-        """get terminology suggestions"""
-        matcher = self.store.translation_project.gettermmatcher()
-        if matcher is None:
-            return []
-
-        return matcher.matches(self.source)
-
     def get_last_updated_info(self):
         return int(dateformat.format(self.creation_time, 'U'))
 
@@ -1159,14 +1159,6 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
     @property
     def real_path(self):
         return self.file.name
-
-    @property
-    def has_terminology(self):
-        """is this a project specific terminology store?"""
-        # TODO: Consider if this should check if the store belongs to a
-        # terminology project. Probably not, in case this might be called over
-        # several files in a project.
-        return self.name.startswith('pootle-terminology')
 
     @property
     def units(self):

--- a/pootle/apps/pootle_store/views.py
+++ b/pootle/apps/pootle_store/views.py
@@ -371,7 +371,7 @@ class UnitTimelineJSON(PootleUnitJSON):
 class UnitEditJSON(PootleUnitJSON):
 
     def get_edit_template(self):
-        if self.project.is_terminology or self.store.has_terminology:
+        if self.project.is_terminology:
             return loader.get_template('editor/units/term_edit.html')
         return loader.get_template('editor/units/edit.html')
 

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -389,17 +389,6 @@ class TranslationProject(models.Model, CachedTreeItem):
             except TranslationProject.DoesNotExist:
                 pass
 
-            local_terminology = self.stores.live().filter(
-                name__startswith='pootle-terminology')
-            for store in local_terminology.iterator():
-                if mtime is None:
-                    mtime = store.get_cached_value(CachedMethods.MTIME)
-                else:
-                    mtime = max(mtime,
-                                store.get_cached_value(CachedMethods.MTIME))
-
-            terminology_stores = terminology_stores | local_terminology
-
         if mtime is None:
             return
 

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -1,7 +1,7 @@
 {% load core i18n common_tags store_tags cleanhtml cache locale %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
-{% cache settings.POOTLE_CACHE_TIMEOUT unit_edit unit.id unit.mtime cantranslate cansuggest canreview altsrcs user.id LANGUAGE_CODE unit.get_terminology %}
+{% cache settings.POOTLE_CACHE_TIMEOUT unit_edit unit.id unit.mtime cantranslate cansuggest canreview altsrcs user.id LANGUAGE_CODE unit.terminology %}
 <td colspan="2" rowspan="1" class="js-editor-cell translate-full translate-focus{% if unit.isfuzzy %} fuzzy-unit{% endif %}" dir="{% locale_dir %}">
   <div class="translate-lightbox js-translate-lightbox"></div>
   <div class="translate-container{% if unit.get_active_critical_qualitychecks.exists %} error{% endif %}">
@@ -40,7 +40,7 @@
       {% endif %}
 
       <!-- Terminology suggestions -->
-      {% with unit.get_terminology as terms %}
+      {% with unit.terminology as terms %}
       {% if terms %}
       <div id="tm" class="sidebar" dir="{% locale_dir %}">
         <span class="sidetitle" lang="{{ LANGUAGE_CODE }}">{% trans "Terminology:" %}</span>


### PR DESCRIPTION
This PR removes 3 queries from requests done to the editing widget:
* The code retrieving terminology matches was being called twice from templates, hence doubling the amount of needed queries.
* The local terminology is unused, and this incurs in an extra query per every unit access. In case it's needed, there are better ways to support this feature so for now we better take it away.