### PR TITLE
TreeItem-related minor cleanups

### DIFF
--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -132,9 +132,10 @@ class TreeItem(object):
         return any(map(lambda x: x.is_dirty(), self.children))
 
     def initialize_children(self):
-        if not self.initialized:
-            self._children = self.get_children()
-            self.initialized = True
+        if self.initialized:
+            return
+        self._children = self.get_children()
+        self.initialized = True
 
     @property
     def children(self):

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -185,22 +185,6 @@ class TreeItem(object):
 
         return result
 
-    def _calc(self, name):
-        if name == CachedMethods.WORDCOUNT_STATS:
-            return self._calc_wordcount_stats()
-        elif name == CachedMethods.SUGGESTIONS:
-            return self._calc_suggestion_count()
-        elif name == CachedMethods.LAST_ACTION:
-            return self._calc_last_action()
-        elif name == CachedMethods.LAST_UPDATED:
-            return self._calc_last_updated()
-        elif name == CachedMethods.CHECKS:
-            return self._calc_checks()
-        elif name == CachedMethods.MTIME:
-            return self._calc_mtime()
-
-        return None
-
     def get_stats(self, include_children=True):
         """Get stats for this particular tree item.
 
@@ -294,7 +278,16 @@ class CachedTreeItem(TreeItem):
         """calculate stat value and update cached value"""
         start = datetime.now()
 
-        self.set_cached_value(name, self._calc(name))
+        calc_fn = {
+            CachedMethods.WORDCOUNT_STATS: self._calc_wordcount_stats,
+            CachedMethods.SUGGESTIONS: self._calc_suggestion_count,
+            CachedMethods.LAST_ACTION: self._calc_last_action,
+            CachedMethods.LAST_UPDATED: self._calc_last_updated,
+            CachedMethods.CHECKS: self._calc_checks,
+            CachedMethods.MTIME: self._calc_mtime,
+        }.get(name, lambda: None)
+
+        self.set_cached_value(name, calc_fn())
 
         end = datetime.now()
         ctx = {

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -224,17 +224,17 @@ class TreeItem(object):
         }
 
         try:
-            result.update(self._calc(CachedMethods.WORDCOUNT_STATS))
+            result.update(self._calc_wordcount_stats())
         except NoCachedStats:
             pass
 
         try:
-            result['suggestions'] = self._calc(CachedMethods.SUGGESTIONS)
+            result['suggestions'] = self._calc_suggestion_count()
         except NoCachedStats:
             pass
 
         try:
-            result['lastaction'] = self._calc(CachedMethods.LAST_ACTION)
+            result['lastaction'] = self._calc_last_action()
         except NoCachedStats:
             pass
 
@@ -244,7 +244,7 @@ class TreeItem(object):
             pass
 
         try:
-            result['lastupdated'] = self._calc(CachedMethods.LAST_UPDATED)
+            result['lastupdated'] = self._calc_last_updated()
         except NoCachedStats:
             pass
 
@@ -256,7 +256,7 @@ class TreeItem(object):
         return result
 
     def get_error_unit_count(self):
-        check_stats = self._calc(CachedMethods.CHECKS)
+        check_stats = self._calc_checks()
         if check_stats is not None:
             return check_stats.get('unit_critical_error_count', 0)
 
@@ -264,7 +264,7 @@ class TreeItem(object):
 
     def get_checks(self):
         try:
-            return self._calc(CachedMethods.CHECKS)['checks']
+            return self._calc_checks()['checks']
         except NoCachedStats:
             return None
 

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -307,14 +307,14 @@ class CachedTreeItem(TreeItem):
     def get_cached(self, name):
         """get stat value from cache"""
         result = self.get_cached_value(name)
-        if result is None:
+        if result is not None:
+            return result
 
-            msg = u"cache miss %s for %s(%s)" % (name, self.get_cachekey(),
-                                                 self.__class__)
-            logger.info(msg)
-            raise NoCachedStats(msg)
-
-        return result
+        logger.debug(
+            u'Cache miss %s for %s(%s)',
+            name, self.get_cachekey(), self.__class__
+        )
+        raise NoCachedStats
 
     def get_checks(self):
         try:

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -139,8 +139,7 @@ class TreeItem(object):
 
     @property
     def children(self):
-        if not self.initialized:
-            self.initialize_children()
+        self.initialize_children()
         return self._children
 
     def _calc_suggestion_count(self):


### PR DESCRIPTION
This PR simplifies and cleans up some code within the tree item mixins. There is no functional change, only the logging level of messages has been moved to `DEBUG`, as these include pure debugging information.