### PR TITLE
Store.update: remove unused `resolve_conflict` parameter

### DIFF
--- a/pootle/apps/pootle_store/constants.py
+++ b/pootle/apps/pootle_store/constants.py
@@ -43,10 +43,6 @@ PARSED = 1
 # Quality checks run
 CHECKED = 2
 
-# Resolve conflict flags for Store.update
-POOTLE_WINS = 1
-SOURCE_WINS = 2
-
 LANGUAGE_REGEX = r"[^/]{2,255}"
 PROJECT_REGEX = r"[^/]{1,255}"
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -51,9 +51,7 @@ from pootle_misc.util import import_func
 from pootle_statistics.models import (Submission, SubmissionFields,
                                       SubmissionTypes)
 
-from .constants import (
-    FUZZY, NEW, OBSOLETE, PARSED, POOTLE_WINS,
-    TRANSLATED, UNTRANSLATED)
+from .constants import FUZZY, NEW, OBSOLETE, PARSED, TRANSLATED, UNTRANSLATED
 from .fields import MultiStringField, TranslationStoreField
 from .managers import StoreManager, SuggestionManager, UnitManager
 from .util import SuggestionStates
@@ -1349,7 +1347,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
             unit.submission_set.add(*subs_created, bulk=False)
 
     def update(self, store, user=None, store_revision=None,
-               submission_type=None, resolve_conflict=POOTLE_WINS):
+               submission_type=None):
         """Update DB with units from a ttk Store.
 
         :param store: a source `Store` instance from TTK.
@@ -1360,7 +1358,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
         """
         self.updater.update(
             store, user=user, store_revision=store_revision,
-            submission_type=submission_type, resolve_conflict=resolve_conflict,
+            submission_type=submission_type,
         )
 
     def deserialize(self, data):

--- a/pootle/apps/pootle_store/updater.py
+++ b/pootle/apps/pootle_store/updater.py
@@ -3,7 +3,7 @@
 # Copyright (C) Pootle contributors.
 # Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -16,7 +16,7 @@ from django.utils.functional import cached_property
 from pootle.core.log import log
 from pootle.core.models import Revision
 
-from .constants import OBSOLETE, PARSED, POOTLE_WINS
+from .constants import OBSOLETE, PARSED
 from .diff import StoreDiff
 from .util import get_change_str
 
@@ -55,10 +55,6 @@ class StoreUpdate(object):
     @property
     def update_revision(self):
         return self.kwargs["update_revision"]
-
-    @property
-    def resolve_conflict(self):
-        return self.kwargs["resolve_conflict"]
 
     @property
     def user(self):
@@ -133,10 +129,7 @@ class UnitUpdater(object):
 
     @property
     def should_update_target(self):
-        return (
-            self.newunit
-            and not (self.conflict_found
-                     and self.update.resolve_conflict == POOTLE_WINS))
+        return self.newunit and not self.conflict_found
 
     @property
     def target_updated(self):
@@ -145,9 +138,7 @@ class UnitUpdater(object):
     def create_suggestion(self):
         return bool(
             self.unit.add_suggestion(self.newunit.target, self.update.user)[1]
-            if self.update.resolve_conflict == POOTLE_WINS
-            else self.unit.add_suggestion(
-                self.original.target, self.original.submitter)[1])
+        )
 
     def record_submission(self):
         self.unit.store.record_submissions(
@@ -220,7 +211,7 @@ class StoreUpdater(object):
             yield unit
 
     def update(self, store, user=None, store_revision=None,
-               submission_type=None, resolve_conflict=POOTLE_WINS):
+               submission_type=None):
         logging.debug(u"Updating %s", self.target_store.pootle_path)
         old_state = self.target_store.state
 
@@ -239,7 +230,6 @@ class StoreUpdater(object):
                     store_revision,
                     diff, update_revision,
                     user, submission_type,
-                    resolve_conflict,
                 )
         finally:
             if old_state < PARSED:
@@ -257,7 +247,7 @@ class StoreUpdater(object):
 
     def update_from_diff(self, store, store_revision,
                          to_change, update_revision, user,
-                         submission_type, resolve_conflict=POOTLE_WINS):
+                         submission_type):
         changes = {}
 
         # Update indexes
@@ -283,7 +273,6 @@ class StoreUpdater(object):
             store,
             user=user,
             submission_type=submission_type,
-            resolve_conflict=resolve_conflict,
             uids=update_dbids,
             indices=uid_index_map,
             store_revision=store_revision,

--- a/pytest_pootle/fixtures/models/store.py
+++ b/pytest_pootle/fixtures/models/store.py
@@ -54,18 +54,10 @@ UPDATE_STORE_TESTS['old_subset_1'] = {
     "update_store": ("MID", UPDATED_STORE_UNITS_1)
 }
 UPDATE_STORE_TESTS['old_subset_2'] = {
-    "update_store": ("MID", UPDATED_STORE_UNITS_2)
-}
-UPDATE_STORE_TESTS['old_subset_2_pootle_wins'] = {
     "update_store": ("MID", UPDATED_STORE_UNITS_2),
-    "fs_wins": False
 }
 UPDATE_STORE_TESTS['old_same_updated'] = {
-    "update_store": ("MID", UPDATED_STORE_UNITS_1 + UPDATED_STORE_UNITS_2)
-}
-UPDATE_STORE_TESTS['old_same_updated_pootle_wins'] = {
     "update_store": ("MID", UPDATED_STORE_UNITS_1 + UPDATED_STORE_UNITS_2),
-    "fs_wins": False
 }
 
 UPDATE_STORE_TESTS['old_unobsolete'] = {
@@ -112,8 +104,6 @@ UPDATE_STORE_TESTS['max_obsolete'] = {
 
 
 def _setup_store_test(store, member, member2, test):
-    from pootle_store.constants import POOTLE_WINS, SOURCE_WINS
-
     setup = test.get("setup", None)
 
     if setup is None:
@@ -134,12 +124,6 @@ def _setup_store_test(store, member, member2, test):
     units_before = [
         unit for unit in store.unit_set.all().order_by("index")]
 
-    fs_wins = test.get("fs_wins", True)
-    if fs_wins:
-        resolve_conflict = SOURCE_WINS
-    else:
-        resolve_conflict = POOTLE_WINS
-
     if store_revision == "MAX":
         store_revision = store.get_max_unit_revision()
 
@@ -147,8 +131,7 @@ def _setup_store_test(store, member, member2, test):
         revisions = [unit.revision for unit in units_before]
         store_revision = sum(revisions) / len(revisions)
 
-    return (store, units_update, store_revision, resolve_conflict,
-            units_before, member, member2)
+    return (store, units_update, store_revision, units_before, member, member2)
 
 
 @pytest.fixture(params=UPDATE_STORE_TESTS.keys())
@@ -181,7 +164,7 @@ def param_update_store_test(request, tp0, member, member2):
         units=test[1],
         store_revision=test[2],
         user=member2,
-        resolve_conflict=test[3])
+    )
     return test
 
 

--- a/pytest_pootle/utils.py
+++ b/pytest_pootle/utils.py
@@ -115,16 +115,12 @@ def create_api_request(rf, method='get', url='/', data='', user=None,
 
 
 def update_store(store, units=None, store_revision=None,
-                 user=None, submission_type=None, resolve_conflict=None):
-    from pootle_store.models import POOTLE_WINS
-
-    if resolve_conflict is None:
-        resolve_conflict = POOTLE_WINS
+                 user=None, submission_type=None):
     store.update(
         store=create_store(units=units),
         store_revision=store_revision,
         user=user, submission_type=submission_type,
-        resolve_conflict=resolve_conflict)
+    )
 
 
 def log_test_start(debug_logger):

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -21,7 +21,7 @@ from django.core.exceptions import ValidationError
 
 from pootle.core.models import Revision
 from pootle.core.url_helpers import to_tp_relative_path
-from pootle_store.constants import OBSOLETE, PARSED, POOTLE_WINS, TRANSLATED
+from pootle_store.constants import OBSOLETE, PARSED, TRANSLATED
 from pootle_store.diff import StoreDiff
 from pootle_store.models import Store
 from pootle_store.syncer import PoStoreSyncer
@@ -247,7 +247,7 @@ def _test_store_update_indexes(store, *test_args):
 
 def _test_store_update_units_before(*test_args):
     # test what has happened to the units that were present before the update
-    (store, units_update, store_revision, resolve_conflict,
+    (store, units_update, store_revision,
      units_before, member_, member2) = test_args
 
     updates = {unit[0]: unit[1] for unit in units_update}
@@ -295,20 +295,14 @@ def _test_store_update_units_before(*test_args):
                 else:
                     # conflict found
                     suggestion = updated_unit.get_suggestions()[0]
-                    if resolve_conflict == POOTLE_WINS:
-                        assert updated_unit.target == unit.target
-                        assert updated_unit.submitted_by == unit.submitted_by
-                        assert suggestion.target == updates[unit.source]
-                        assert suggestion.user == member2
-                    else:
-                        assert updated_unit.target == updates[unit.source]
-                        assert updated_unit.submitted_by == member2
-                        assert suggestion.target == unit.target
-                        assert suggestion.user == unit.submitted_by
+                    assert updated_unit.target == unit.target
+                    assert updated_unit.submitted_by == unit.submitted_by
+                    assert suggestion.target == updates[unit.source]
+                    assert suggestion.user == member2
 
 
 def _test_store_update_ordering(*test_args):
-    (store, units_update, store_revision, resolve_conflict_,
+    (store, units_update, store_revision,
      units_before, member_, member2_) = test_args
 
     updates = {unit[0]: unit[1] for unit in units_update}
@@ -335,7 +329,7 @@ def _test_store_update_ordering(*test_args):
 
 
 def _test_store_update_units_now(*test_args):
-    (store, units_update, store_revision, resolve_conflict_,
+    (store, units_update, store_revision,
      units_before, member_, member2_) = test_args
 
     # test that all the current units should be there


### PR DESCRIPTION
This was added in the context of FS code, and now it was always evaluating to
the same value.