### PR TITLE
APIView: implement permission handling

### DIFF
--- a/pootle/core/views/api.py
+++ b/pootle/core/views/api.py
@@ -20,6 +20,7 @@ from django.views.generic import View
 
 from pootle.core.http import (
     JsonResponse, JsonResponseBadRequest, JsonResponseForbidden,
+    JsonResponseNotFound
 )
 
 
@@ -135,6 +136,11 @@ class APIView(View):
 
     def handle_exception(self, exc):
         """Handles response exceptions."""
+        if isinstance(exc, Http404):
+            return JsonResponseNotFound({
+                'msg': 'Not found',
+            })
+
         if isinstance(exc, PermissionDenied):
             return JsonResponseForbidden({
                 'msg': 'Permission denied.',

--- a/pootle/core/views/api.py
+++ b/pootle/core/views/api.py
@@ -114,16 +114,16 @@ class APIView(View):
 
     def get(self, request, *args, **kwargs):
         """GET handler."""
-        if kwargs.get(self.pk_field_name, None) is not None:
-            object = self.get_object(*args, **kwargs)
+        if self.kwargs.get(self.pk_field_name, None) is not None:
+            object = self.get_object()
             return JsonResponse(self.object_to_values(object))
 
         return self.get_collection(request, *args, **kwargs)
 
-    def get_object(self, *args, **kwargs):
+    def get_object(self):
         """Returns a single model instance."""
         return get_object_or_404(
-            self.base_queryset, pk=kwargs[self.pk_field_name],
+            self.base_queryset, pk=self.kwargs[self.pk_field_name],
         )
 
     def get_collection(self, request, *args, **kwargs):
@@ -152,7 +152,7 @@ class APIView(View):
 
     def put(self, request, *args, **kwargs):
         """Update the current model."""
-        if self.pk_field_name not in kwargs:
+        if self.pk_field_name not in self.kwargs:
             return self.status_msg('PUT is not supported for collections',
                                    status=405)
 
@@ -161,7 +161,7 @@ class APIView(View):
         except ValueError:
             return self.status_msg('Invalid JSON data', status=400)
 
-        instance = self.get_object(*args, **kwargs)
+        instance = self.get_object()
         form = self.edit_form_class(request_dict, instance=instance)
 
         if form.is_valid():
@@ -176,7 +176,7 @@ class APIView(View):
             return self.status_msg('DELETE is not supported for collections',
                                    status=405)
 
-        qs = self.base_queryset.filter(id=kwargs[self.pk_field_name])
+        qs = self.base_queryset.filter(id=self.kwargs[self.pk_field_name])
         if qs:
             output = self.qs_to_values(qs)
             obj = qs[0]

--- a/pootle/core/views/api.py
+++ b/pootle/core/views/api.py
@@ -114,11 +114,11 @@ class APIView(View):
     def get(self, request, *args, **kwargs):
         """GET handler."""
         if kwargs.get(self.pk_field_name, None) is not None:
-            return self.get_single_item(request, *args, **kwargs)
+            return self.get_object(request, *args, **kwargs)
 
         return self.get_collection(request, *args, **kwargs)
 
-    def get_single_item(self, request, *args, **kwargs):
+    def get_object(self, request, *args, **kwargs):
         """Returns a single model instance."""
         try:
             qs = self.base_queryset.filter(pk=kwargs[self.pk_field_name])

--- a/tests/core/views.py
+++ b/tests/core/views.py
@@ -12,7 +12,6 @@ import json
 import pytest
 
 from django import forms
-from django.http import Http404
 
 from pytest_pootle.factories import UserFactory
 from pytest_pootle.utils import create_api_request
@@ -89,8 +88,8 @@ def test_apiview_get_single(rf):
     assert 'email' not in response_data
 
     # Non-existent IDs should return 404
-    with pytest.raises(Http404):
-        view(request, id='777')
+    response = view(request, id='777')
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db
@@ -218,8 +217,8 @@ def test_apiview_put(rf):
     request = create_api_request(rf, 'put', data=update_data)
 
     # Requesting unknown resources is a 404
-    with pytest.raises(Http404):
-        view(request, id='11')
+    response = view(request, id='11')
+    assert response.status_code == 404
 
     # All fields must be submitted
     response = view(request, id=user.id)
@@ -277,8 +276,8 @@ def test_apiview_delete(rf):
     assert User.objects.filter(id=user.id).count() == 0
 
     # Should raise 404 if we try to access a deleted resource again:
-    with pytest.raises(Http404):
-        view(request, id=user.id)
+    response = view(request, id=user.id)
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/tests/core/views.py
+++ b/tests/core/views.py
@@ -256,6 +256,19 @@ def test_apiview_put(rf):
 
 
 @pytest.mark.django_db
+def test_apiview_put_multiple(rf):
+    """Tests updating an object using the API."""
+    view = WriteableUserAPIView.as_view()
+
+    request = create_api_request(rf, 'put')
+    response = view(request)
+    response_data = json.loads(response.content)
+
+    assert response.status_code == 405
+    assert response_data['msg'] == 'PUT is not supported for collections'
+
+
+@pytest.mark.django_db
 def test_apiview_delete(rf):
     """Tests deleting an object using the API."""
     view = UserAPIView.as_view()


### PR DESCRIPTION
This PR implements generic permission handling for `APIView`s, which will come handy for due dates. These need to specify a `permission_classes` member with a list of classes that check permissions. An empty list (the default) means no permission checking.

Permission classes need to implement a `has_permission` method and return a boolean indicating whether the request is permitted to be processed or not. This can be extended in the future to implement object-specific permissions in views.

The PR also includes a few cleanups that helped implement this, along with an exception handler for dispatch methods — this way the permission checking code can raise an exception, and it will be handled transparently. To some extent this shadows the functionality available in the `errorpages` middleware, although I'm inclined to think such site-wide generic error handling should be reserved for 500-like errors.