### PR TITLE
Tests: disable captcha for views

### DIFF
--- a/tests/models/submission.py
+++ b/tests/models/submission.py
@@ -145,9 +145,8 @@ def test_update_submission_ordering():
 
 
 @pytest.mark.django_db
-def test_new_translation_submission_ordering(client, request_users, settings):
+def test_new_translation_submission_ordering(client, request_users):
     unit = Unit.objects.filter(state=UNTRANSLATED).first()
-    settings.POOTLE_CAPTCHA_ENABLED = False
     user = request_users["user"]
     if user.username != "nobody":
         client.force_login(user)
@@ -172,9 +171,8 @@ def test_new_translation_submission_ordering(client, request_users, settings):
 
 
 @pytest.mark.django_db
-def test_accept_sugg_submission_ordering(client, request_users, settings):
+def test_accept_sugg_submission_ordering(client, request_users):
     """Tests suggestion can be accepted with a comment."""
-    settings.POOTLE_CAPTCHA_ENABLED = False
     unit = Unit.objects.filter(suggestion__state='pending',
                                state=UNTRANSLATED)[0]
     unit.markfuzzy()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -28,6 +28,8 @@ POOTLE_MT_BACKENDS = [
     ['fake_test_backend', 'api_key']
 ]
 
+POOTLE_CAPTCHA_ENABLED = False
+
 
 MIDDLEWARE_CLASSES = [
     #: Must be as high as possible (see above)

--- a/tests/views/unit.py
+++ b/tests/views/unit.py
@@ -61,9 +61,8 @@ def test_get_uids_ordered(rf, default, admin, numbered_po):
 
 
 @pytest.mark.django_db
-def test_submit_with_suggestion_and_comment(client, request_users, settings):
+def test_submit_with_suggestion_and_comment(client, request_users):
     """Tests translation can be applied after suggestion is accepted."""
-    settings.POOTLE_CAPTCHA_ENABLED = False
     Comment = get_comment_model()
     unit = Unit.objects.filter(suggestion__state='pending',
                                state=UNTRANSLATED)[0]
@@ -102,9 +101,8 @@ def test_submit_with_suggestion_and_comment(client, request_users, settings):
 
 
 @pytest.mark.django_db
-def test_submit_with_suggestion(client, request_users, settings):
+def test_submit_with_suggestion(client, request_users):
     """Tests translation can be applied after suggestion is accepted."""
-    settings.POOTLE_CAPTCHA_ENABLED = False
     unit = Unit.objects.filter(suggestion__state='pending',
                                state=UNTRANSLATED).first()
     unit_submissions = Submission.objects.filter(unit=unit)
@@ -142,9 +140,8 @@ def test_submit_with_suggestion(client, request_users, settings):
 
 
 @pytest.mark.django_db
-def test_accept_suggestion_with_comment(client, request_users, settings):
+def test_accept_suggestion_with_comment(client, request_users):
     """Tests suggestion can be accepted with a comment."""
-    settings.POOTLE_CAPTCHA_ENABLED = False
     Comment = get_comment_model()
     unit = Unit.objects.filter(suggestion__state='pending',
                                state=UNTRANSLATED)[0]
@@ -239,9 +236,8 @@ def test_toggle_quality_check(rf, admin):
 
 
 @pytest.mark.django_db
-def test_submit_unit_plural(client, unit_plural, request_users, settings):
+def test_submit_unit_plural(client, unit_plural, request_users):
     """Tests translation can be applied after suggestion is accepted."""
-    settings.POOTLE_CAPTCHA_ENABLED = False
     user = request_users["user"]
     if user.username != "nobody":
         client.force_login(user)


### PR DESCRIPTION
Avoids getting it in the way. Tests that need to check for it can still
explicitly enable it.