### PR TITLE
APIView: simplify delete method

### DIFF
--- a/pootle/core/views/api.py
+++ b/pootle/core/views/api.py
@@ -221,17 +221,12 @@ class APIView(View):
             return self.status_msg('DELETE is not supported for collections',
                                    status=405)
 
-        qs = self.base_queryset.filter(id=self.kwargs[self.pk_field_name])
-        if qs:
-            output = self.qs_to_values(qs)
-            obj = qs[0]
-            try:
-                obj.delete()
-                return JsonResponse(output)
-            except ProtectedError as e:
-                return self.status_msg(e[0], status=405)
-
-        raise Http404
+        obj = self.get_object()
+        try:
+            obj.delete()
+            return JsonResponse({})
+        except ProtectedError as e:
+            return self.status_msg(e[0], status=405)
 
     def object_to_values(self, object):
         """Convert an object to values for serialization."""

--- a/pytest_pootle/fixtures/models/user.py
+++ b/pytest_pootle/fixtures/models/user.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -52,6 +53,12 @@ def request_users(request):
 
 @pytest.fixture(scope="session", params=TEST_USERS.keys())
 def site_users(request):
+    return _get_user(request.param)
+
+
+@pytest.fixture(scope='session', params=['default', 'nobody', 'system'])
+def meta_users(request):
+    """Require meta users."""
     return _get_user(request.param)
 
 

--- a/tests/core/views.py
+++ b/tests/core/views.py
@@ -374,6 +374,19 @@ def test_apiview_unhandled_exception(rf):
 
 
 @pytest.mark.django_db
+def test_apiview_delete_meta_user(rf, meta_users):
+    """Tests meta users cannot be removed."""
+    user = meta_users['user']
+
+    request = create_api_request(rf, 'delete')
+    view = UserAPIView.as_view()
+
+    response = view(request, id=user.id)
+    assert response.status_code == 405
+    assert 'Cannot remove meta user instances' in response.content
+
+
+@pytest.mark.django_db
 def test_view_gathered_context_data(rf, member):
 
     from pootle.core.views.base import PootleDetailView


### PR DESCRIPTION
Reuses `get_object()` and doesn't return the previous object as part
of the response.