### PR TITLE
UnixTimeStampField: also accept integers

### DIFF
--- a/pootle/forms/fields.py
+++ b/pootle/forms/fields.py
@@ -24,9 +24,15 @@ class UnixTimestampField(forms.Field):
         if isinstance(value, datetime):
             return make_aware(value)
 
-        if isinstance(value, basestring):
+        if isinstance(value, int) or isinstance(value, basestring):
             try:
-                return make_aware(datetime.fromtimestamp(float(value)))
+                value = float(value)
+            except ValueError:
+                pass
+
+        if isinstance(value, float):
+            try:
+                return make_aware(datetime.fromtimestamp(value))
             except ValueError:
                 pass
 

--- a/tests/forms/fields.py
+++ b/tests/forms/fields.py
@@ -27,11 +27,13 @@ def test_unixtimestamp_clean():
     # so remove potential microseconds.
     assert field.clean(timestamp) == reference_datetime.replace(microsecond=0)
 
+    # Also check with the timestamp as an int
+    assert field.clean(int(timestamp)) == reference_datetime.replace(microsecond=0)
+
 
 @pytest.mark.parametrize('invalid_value', [
     None,
     'invalid',
-    1234567890,
     datetime.date(2015, 05, 05),
 ])
 def test_unixtimestamp_invalid(invalid_value):


### PR DESCRIPTION
Data being fed to the form field is potentially coming from a JSON
deserialization, and it's very likely timestamps are interpreted as integers.