### PR TITLE
Update .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,5 @@
 coverage:
   ignore:
-    - "pytest_pootle/*"
-    - "tests/*"
+    - "pytest_pootle/.*"
+    - "tests/.*"
 comment: off


### PR DESCRIPTION
We needed to respect both `glob` and `regexp`, hence this pr 👍 