### PR TITLE
Upgrade to webpack 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Zing Changelog
 v0.3.1 (in development)
 -----------------------
 
+* JS assets are now built using Webpack 2 (#131).
+
 
 v0.3.0 (2017-02-06)
 -------------------

--- a/pootle/static/js/admin/app.js
+++ b/pootle/static/js/admin/app.js
@@ -6,7 +6,7 @@
  * AUTHORS file for copyright and authorship information.
  */
 
-import 'imports?Backbone=>require("backbone")!backbone-move';
+import 'imports-loader?Backbone=>require("backbone")!backbone-move';
 
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -30,7 +30,7 @@
     "style-loader": "^0.8.0",
     "stylelint": "^7.1.0",
     "stylelint-config-standard": "^12.0.0",
-    "webpack": "^1.9.8"
+    "webpack": "^2.2.1"
   },
   "dependencies": {
     "autolinker": "^0.11.2",

--- a/pootle/static/js/shared/components/CodeMirror.js
+++ b/pootle/static/js/shared/components/CodeMirror.js
@@ -38,7 +38,7 @@ const CodeMirror = React.createClass({
     const mode = getMode(this.props.markup);
 
     // Using webpack's `bundle` loader so each mode goes into a separate chunk
-    const bundledResult = require(`bundle!codemirror/mode/${mode}/${mode}.js`);
+    const bundledResult = require(`bundle-loader!codemirror/mode/${mode}/${mode}.js`);
     bundledResult(() => {
       this.codemirror = CM.fromTextArea(this.refs.editor, {
         mode,

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -122,7 +122,10 @@ plugins.push.apply(plugins, [
   new webpack.ProvidePlugin({
     'window.Backbone': 'backbone',
   }),
-  new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.bundle.js')
+  new webpack.optimize.CommonsChunkPlugin({
+    name: 'vendor',
+    filename: 'vendor.bundle.js',
+  }),
 ]);
 
 

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -110,7 +110,6 @@ var plugins = [];
 if (!DEBUG) {
   plugins = [
     new webpack.optimize.UglifyJsPlugin(),
-    new webpack.optimize.OccurenceOrderPlugin(),
   ];
 } else {
   env = 'development';

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) Pootle contributors.
+ * Copyright (C) Zing contributors.
  *
- * This file is a part of the Pootle project. It is distributed under the GPL3
+ * This file is a part of the Zing project. It is distributed under the GPL3
  * or later license. See the LICENSE file for a copy of the license and the
  * AUTHORS file for copyright and authorship information.
  */
@@ -159,15 +160,11 @@ var config = {
     ]
   },
   resolve: resolve,
-  resolveLoader: {
-    root: path.join(__dirname, 'node_modules'),
-  },
   plugins: plugins,
 };
 
 
 if (DEBUG) {
-  config.debug = true;
   config.devtool = '#source-map';
   config.output.pathinfo = true;
 }

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -103,10 +103,7 @@ var plugins = [];
 
 if (!DEBUG) {
   plugins = [
-    new webpack.optimize.UglifyJsPlugin({
-      compress: { warnings: false },
-      sourceMap: false,
-    }),
+    new webpack.optimize.UglifyJsPlugin(),
     new webpack.optimize.OccurenceOrderPlugin(),
   ];
 } else {

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -29,7 +29,6 @@ var entries = {
 
 
 var resolve = {
-  extensions: ['', '.js'],
   modulesDirectories: ['node_modules', 'shared'],
   alias: {
     pootle: __dirname,

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -138,12 +138,18 @@ var config = {
     chunkFilename: '[name]/app.bundle.js'
   },
   module: {
-    loaders: [
-      { test: /\.css/, loader: 'style-loader!css-loader' },
+    rules: [
+      {
+        test: /\.css/,
+        use: [
+          'style-loader',
+          'css-loader',
+        ],
+      },
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        query: {
+        options: {
           babelrc: false,
           cacheDirectory: true,
           presets: [
@@ -152,8 +158,8 @@ var config = {
           ],
         },
         exclude: /node_modules|vendor|.*\.test\.js/,
-      }
-    ]
+      },
+    ],
   },
   resolve: resolve,
   plugins: plugins,

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -29,7 +29,10 @@ var entries = {
 
 
 var resolve = {
-  modulesDirectories: ['node_modules', 'shared'],
+  modules: [
+    'node_modules',
+    'shared',
+  ],
   alias: {
     pootle: __dirname,
 
@@ -61,12 +64,15 @@ var resolve = {
 };
 
 
-// Read extra `resolve.root` paths from the `WEBPACK_ROOT` envvar
+// Read extra `resolve.modules` paths from the `WEBPACK_ROOT` envvar
 // and merge the entry definitions from the manifest files
 var root = process.env.WEBPACK_ROOT;
 if (root !== undefined) {
   var customPaths = root.split(';');
-  resolve.root = [path.join(__dirname, 'node_modules')].concat(customPaths);
+  resolve.modules.push(path.join(__dirname, 'node_modules'));
+  customPaths.forEach(path => {
+    resolve.modules.push(path);
+  });
 
   function mergeWithArrays(target, source) {
     var rv = Object(target);


### PR DESCRIPTION
This PR upgrades webpack to v2.2 and makes all the required configuration changes. The resulting bundles are a bit smaller due to tree shaking.

Fixes #131.