### PR TITLE
LiveEditor: remove bogus reference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ v0.3.1 (in development)
 -----------------------
 
 * JS assets are now built using Webpack 2 (#131).
+* Fixed reference in static pages which prevented the editor from showing up.
 
 
 v0.3.0 (2017-02-06)

--- a/pootle/static/js/admin/general/components/LiveEditor.js
+++ b/pootle/static/js/admin/general/components/LiveEditor.js
@@ -64,7 +64,6 @@ export const LiveEditor = React.createClass({
   getContentHeight() {
     const topHeight = (
       outerHeight(q('#navbar')) +
-      outerHeight(q('#header-meta')) +
       outerHeight(q('#header-tabs'))
     );
 


### PR DESCRIPTION
This was causing a JS error which prevented the editor from showing up.