### PR TITLE
DueDateForm: require less fields in edit form

### DIFF
--- a/pootle/forms/__init__.py
+++ b/pootle/forms/__init__.py
@@ -6,7 +6,7 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-from .duedate import DueDateForm
+from .duedate import AddDueDateForm, EditDueDateForm
 
 
-__all__ = ('DueDateForm',)
+__all__ = ('AddDueDateForm', 'EditDueDateForm', )

--- a/pootle/forms/duedate.py
+++ b/pootle/forms/duedate.py
@@ -12,10 +12,17 @@ from pootle.forms.fields import UnixTimestampField
 from pootle.models import DueDate
 
 
-class DueDateForm(forms.ModelForm):
+class AddDueDateForm(forms.ModelForm):
 
     due_on = UnixTimestampField()
 
     class Meta:
         model = DueDate
         fields = ('due_on', 'pootle_path', 'modified_by', )
+
+
+class EditDueDateForm(AddDueDateForm):
+
+    class Meta:
+        model = DueDate
+        fields = ('due_on', )

--- a/pootle/views/api/duedate.py
+++ b/pootle/views/api/duedate.py
@@ -11,7 +11,7 @@ from django.utils.lru_cache import lru_cache
 
 from pootle.core.url_helpers import split_pootle_path
 from pootle.core.views.api import APIView
-from pootle.forms import DueDateForm
+from pootle.forms import AddDueDateForm, EditDueDateForm
 from pootle.models import DueDate
 from pootle_app.models.permissions import check_user_permission
 from pootle_language.models import Language
@@ -88,8 +88,8 @@ class DueDateView(APIView):
     model = DueDate
     restrict_to_methods = ('POST', 'PUT', 'DELETE', )
     fields = ('due_on', 'modified_by', 'pootle_path', )
-    add_form_class = DueDateForm
-    edit_form_class = DueDateForm
+    add_form_class = AddDueDateForm
+    edit_form_class = EditDueDateForm
     permission_classes = [CanAdminPath]
     path_field = 'pootle_path'
 


### PR DESCRIPTION
This allows to update due dates without passing redundant data.