### PR TITLE
timeDelta: interface with milliseconds since epoch

### DIFF
--- a/pootle/static/js/helpers.js
+++ b/pootle/static/js/helpers.js
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) Pootle contributors.
+ * Copyright (C) Zing contributors.
  *
- * This file is a part of the Pootle project. It is distributed under the GPL3
+ * This file is a part of the Zing project. It is distributed under the GPL3
  * or later license. See the LICENSE file for a copy of the license and the
  * AUTHORS file for copyright and authorship information.
  */
@@ -25,7 +26,7 @@ const helpers = {
   /* Updates relative dates */
   updateRelativeDates() {
     $('.js-relative-date').each((i, e) => {
-      $(e).text(relativeTime($(e).attr('datetime')));
+      $(e).text(relativeTime(Date.parse($(e).attr('datetime'))));
     });
   },
 

--- a/pootle/static/js/shared/components/TimeSince.js
+++ b/pootle/static/js/shared/components/TimeSince.js
@@ -73,7 +73,8 @@ const TimeSince = React.createClass({
       return null;
     }
 
-    const d = new Date(this.props.timestamp * 1000);
+    const msEpoch = this.props.timestamp * 1000;
+    const d = new Date(msEpoch);
 
     return (
       <time
@@ -82,7 +83,7 @@ const TimeSince = React.createClass({
         dateTime={d.toUTCString()}
         {...this.props}
       >
-        {relativeTime(d)}
+        {relativeTime(msEpoch)}
       </time>
     );
   },

--- a/pootle/static/js/shared/utils/relativeTime.js
+++ b/pootle/static/js/shared/utils/relativeTime.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) Pootle contributors.
+ * Copyright (C) Zing contributors.
  *
- * This file is a part of the Pootle project. It is distributed under the GPL3
+ * This file is a part of the Zing project. It is distributed under the GPL3
  * or later license. See the LICENSE file for a copy of the license and the
  * AUTHORS file for copyright and authorship information.
  */
@@ -68,15 +68,14 @@ function relativeTimeMessage({
 /**
  * Generate a human-readable relative time message.
  *
- * @param {String} isoDateTime - a date and time combination in ISO 8601 format
- * as understood by browsers' `Date.parse()`.
+ * @param {String} msEpoch - Number of milliseconds since epoch.
  * @return {String} - Message referring to the relative time. Returns an empty
  * string if the provided date time is invalid or cannot be parsed.
  */
-export function relativeTime(isoDateTime) {
+export function relativeTime(msEpoch) {
   const {
     isFuture, minutes, hours, days, weeks, months, years,
-  } = timeDelta(isoDateTime);
+  } = timeDelta(msEpoch);
 
   if (isFuture === null) {
     return '';

--- a/pootle/static/js/shared/utils/relativeTime.test.js
+++ b/pootle/static/js/shared/utils/relativeTime.test.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) Pootle contributors.
+ * Copyright (C) Zing contributors.
  *
- * This file is a part of the Pootle project. It is distributed under the GPL3
+ * This file is a part of the Zing project. It is distributed under the GPL3
  * or later license. See the LICENSE file for a copy of the license and the
  * AUTHORS file for copyright and authorship information.
  */
@@ -23,7 +23,9 @@ describe('relativeTime', () => {
     expect(relativeTime(undefined)).toEqual('');
     expect(relativeTime('Invalid')).toEqual('');
     expect(relativeTime('2016-14-12')).toEqual('');
+    expect(relativeTime('2016-12-12 12:02:11')).toEqual('');
     expect(relativeTime('2016-12-12 25:02:11')).toEqual('');
+    expect(relativeTime('2016-12-12T12:02:11+00:00')).toEqual('');
   });
 });
 

--- a/pootle/static/js/shared/utils/time.js
+++ b/pootle/static/js/shared/utils/time.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) Pootle contributors.
+ * Copyright (C) Zing contributors.
  *
- * This file is a part of the Pootle project. It is distributed under the GPL3
+ * This file is a part of the Zing project. It is distributed under the GPL3
  * or later license. See the LICENSE file for a copy of the license and the
  * AUTHORS file for copyright and authorship information.
  */
@@ -28,23 +28,21 @@ function absTrunc(number) {
 
 
 /**
- * Calculates the time difference from `isoDateTime` to the current date as
- * provide by the client.
+ * Calculates the time difference from `msEpoch` to the current date as
+ * provided by the client.
  *
  * Note the difference calculation doesn't intend to be smart about leap years
  * and number of days per month, but rather a simple and naive implementation.
  *
- * @param {String} isoDateTime - a date and time combination in ISO 8601 format
- * as understood by browsers' `Date.parse()`.
+ * @param {String} msEpoch - Number of milliseconds since epoch.
  * @return {Object} - An object with the delta difference specified in seconds,
  * minutes, hours, days, weeks and months. The `isFuture` boolean
  * property indicates whether the difference refers to a future time.
  * When the value passed is invalid or cannot be parsed, every property in the
  * object will be `null`.
  */
-export function timeDelta(isoDateTime) {
-  const providedTime = isoDateTime && Date.parse(isoDateTime);
-  if (!providedTime || isNaN(providedTime)) {
+export function timeDelta(msEpoch) {
+  if (typeof msEpoch !== 'number') {
     return {
       isFuture: null,
       seconds: null,
@@ -57,8 +55,8 @@ export function timeDelta(isoDateTime) {
     };
   }
 
-  const now = (new Date()).valueOf();
-  const delta = providedTime - now;
+  const now = Date.now();
+  const delta = msEpoch - now;
 
   const isFuture = delta > 0;
 

--- a/pootle/static/js/shared/utils/time.test.js
+++ b/pootle/static/js/shared/utils/time.test.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) Pootle contributors.
+ * Copyright (C) Zing contributors.
  *
- * This file is a part of the Pootle project. It is distributed under the GPL3
+ * This file is a part of the Zing project. It is distributed under the GPL3
  * or later license. See the LICENSE file for a copy of the license and the
  * AUTHORS file for copyright and authorship information.
  */
@@ -30,7 +30,9 @@ describe('timeDelta', () => {
     expect(timeDelta(undefined)).toEqual(undefinedDelta);
     expect(timeDelta('Invalid')).toEqual(undefinedDelta);
     expect(timeDelta('2016-14-12')).toEqual(undefinedDelta);
+    expect(timeDelta('2016-12-12 12:02:11')).toEqual(undefinedDelta);
     expect(timeDelta('2016-12-12 25:02:11')).toEqual(undefinedDelta);
+    expect(timeDelta('2016-12-12T12:02:11+00:00')).toEqual(undefinedDelta);
   });
 
   describe('positive duration', () => {
@@ -38,7 +40,7 @@ describe('timeDelta', () => {
       {
         unit: 'seconds',
         now: '2016-07-07T00:00:00+00:00',
-        args: ['2016-07-07T00:00:44+00:00'],
+        args: '2016-07-07T00:00:44+00:00',
         expected: {
           isFuture: true,
           seconds: 44,
@@ -53,7 +55,7 @@ describe('timeDelta', () => {
       {
         unit: 'seconds (TZ-aware)',
         now: '2016-07-07T00:00:00+02:00',
-        args: ['2016-07-06T22:00:44+00:00'],
+        args: '2016-07-06T22:00:44+00:00',
         expected: {
           isFuture: true,
           seconds: 44,
@@ -68,7 +70,7 @@ describe('timeDelta', () => {
       {
         unit: 'minutes',
         now: '2016-07-07T00:00:00+00:00',
-        args: ['2016-07-07T00:59:00+00:00'],
+        args: '2016-07-07T00:59:00+00:00',
         expected: {
           isFuture: true,
           seconds: 3540,
@@ -83,7 +85,7 @@ describe('timeDelta', () => {
       {
         unit: 'minutes (TZ-aware)',
         now: '2016-07-07T00:00:00+02:00',
-        args: ['2016-07-06T22:59:00+00:00'],
+        args: '2016-07-06T22:59:00+00:00',
         expected: {
           isFuture: true,
           seconds: 3540,
@@ -98,7 +100,7 @@ describe('timeDelta', () => {
       {
         unit: 'hours',
         now: '2016-07-07T00:00:00+00:00',
-        args: ['2016-07-07T23:00:44+00:00'],
+        args: '2016-07-07T23:00:44+00:00',
         expected: {
           isFuture: true,
           seconds: 82844,
@@ -113,7 +115,7 @@ describe('timeDelta', () => {
       {
         unit: 'hours (TZ-aware)',
         now: '2016-07-07T00:00:00+02:00',
-        args: ['2016-07-07T21:00:44+00:00'],
+        args: '2016-07-07T21:00:44+00:00',
         expected: {
           isFuture: true,
           seconds: 82844,
@@ -128,7 +130,7 @@ describe('timeDelta', () => {
       {
         unit: 'days',
         now: '2016-07-07T00:00:00+00:00',
-        args: ['2016-07-13T23:59:59+00:00'],
+        args: '2016-07-13T23:59:59+00:00',
         expected: {
           isFuture: true,
           seconds: 604799,
@@ -143,7 +145,7 @@ describe('timeDelta', () => {
       {
         unit: 'days (TZ-aware)',
         now: '2016-07-07T00:00:00+02:00',
-        args: ['2016-07-13T21:59:59+00:00'],
+        args: '2016-07-13T21:59:59+00:00',
         expected: {
           isFuture: true,
           seconds: 604799,
@@ -158,7 +160,7 @@ describe('timeDelta', () => {
       {
         unit: 'weeks',
         now: '2016-06-27T23:59:59+00:00',
-        args: ['2016-07-07T00:00:00+00:00'],
+        args: '2016-07-07T00:00:00+00:00',
         expected: {
           isFuture: true,
           seconds: 777601,
@@ -173,7 +175,7 @@ describe('timeDelta', () => {
       {
         unit: 'weeks (TZ-aware)',
         now: '2016-06-27T21:59:59+00:00',
-        args: ['2016-07-07T00:00:00+02:00'],
+        args: '2016-07-07T00:00:00+02:00',
         expected: {
           isFuture: true,
           seconds: 777601,
@@ -188,7 +190,7 @@ describe('timeDelta', () => {
       {
         unit: 'months',
         now: '2016-07-07T00:00:00+00:00',
-        args: ['2016-10-07T23:59:59+00:00'],
+        args: '2016-10-07T23:59:59+00:00',
         expected: {
           isFuture: true,
           seconds: 8035199,
@@ -203,7 +205,7 @@ describe('timeDelta', () => {
       {
         unit: 'months (TZ-aware)',
         now: '2016-07-07T00:00:00+02:00',
-        args: ['2016-10-07T21:59:59+00:00'],
+        args: '2016-10-07T21:59:59+00:00',
         expected: {
           isFuture: true,
           seconds: 8035199,
@@ -218,7 +220,7 @@ describe('timeDelta', () => {
       {
         unit: 'years',
         now: '2016-07-07T00:00:00+00:00',
-        args: ['2017-07-07T00:00:59+00:00'],
+        args: '2017-07-07T00:00:59+00:00',
         expected: {
           isFuture: true,
           seconds: 31536059,
@@ -233,7 +235,7 @@ describe('timeDelta', () => {
       {
         unit: 'years (TZ-aware)',
         now: '2016-07-07T00:00:00+00:00',
-        args: ['2017-07-07T00:00:59+00:00'],
+        args: '2017-07-07T00:00:59+00:00',
         expected: {
           isFuture: true,
           seconds: 31536059,
@@ -250,7 +252,7 @@ describe('timeDelta', () => {
     tests.forEach((test) => {
       it(`calculates ${test.unit} of difference`, () => {
         lolex.install(Date.parse(test.now));
-        expect(timeDelta(...test.args)).toEqual(test.expected);
+        expect(timeDelta(Date.parse(test.args))).toEqual(test.expected);
       });
     });
   });
@@ -260,7 +262,7 @@ describe('timeDelta', () => {
       {
         unit: 'seconds',
         now: '2016-07-07T00:00:44+00:00',
-        args: ['2016-07-07T00:00:00+00:00'],
+        args: '2016-07-07T00:00:00+00:00',
         expected: {
           isFuture: false,
           seconds: 44,
@@ -277,7 +279,7 @@ describe('timeDelta', () => {
     tests.forEach((test) => {
       it(`calculates ${test.unit} of difference`, () => {
         lolex.install(Date.parse(test.now));
-        expect(timeDelta(...test.args)).toEqual(test.expected);
+        expect(timeDelta(Date.parse(test.args))).toEqual(test.expected);
       });
     });
   });


### PR DESCRIPTION
To avoid confusion, let's operate with timestamps (in JS, milliseconds since
epoch, as opposed to unix timestamps, which indiceate seconds). Therefore, the
function does not accept ISO8601 dates anymore, but conversion is left up to
callers.