### PR TITLE
JSONEncoder: serialize dates/times to unix timestamps

### DIFF
--- a/pootle/core/utils/json.py
+++ b/pootle/core/utils/json.py
@@ -9,10 +9,12 @@
 
 from __future__ import absolute_import
 
+import datetime
 import json
 
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
+from django.utils import dateformat
 from django.utils.encoding import force_unicode
 from django.utils.functional import Promise
 
@@ -30,6 +32,11 @@ class PootleJSONEncoder(DjangoJSONEncoder):
     def default(self, obj):
         if isinstance(obj, (Promise, Markup)):
             return force_unicode(obj)
+
+        if (isinstance(obj, datetime.datetime) or
+            isinstance(obj, datetime.date) or
+            isinstance(obj, datetime.time)):
+            return dateformat.format(obj, 'U')
 
         try:
             return super(PootleJSONEncoder, self).default(obj)


### PR DESCRIPTION
This changes Django's JSON encoder's default, as we are using timestamps
everywhere when sending down serialized dates over the wire. This way, we save
manual formatting here and there.