### PR TITLE
Update snapshots as default serializing changed

### DIFF
--- a/tests/data/snapshots/test_duedate_post/admin/_language0_.context.json
+++ b/tests/data/snapshots/test_duedate_post/admin/_language0_.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-26T09:00:00+01:00",
+  "due_on": "1485417600",
   "modified_by": "admin",
   "pootle_path": "/language0/"
 }

--- a/tests/data/snapshots/test_duedate_post/admin/_language0_project0_.context.json
+++ b/tests/data/snapshots/test_duedate_post/admin/_language0_project0_.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-26T09:00:00+01:00",
+  "due_on": "1485417600",
   "modified_by": "admin",
   "pootle_path": "/language0/project0/"
 }

--- a/tests/data/snapshots/test_duedate_post/admin/_language0_project0_store0.po.context.json
+++ b/tests/data/snapshots/test_duedate_post/admin/_language0_project0_store0.po.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-26T09:00:00+01:00",
+  "due_on": "1485417600",
   "modified_by": "admin",
   "pootle_path": "/language0/project0/store0.po"
 }

--- a/tests/data/snapshots/test_duedate_post/admin/_language0_project0_subdir0_.context.json
+++ b/tests/data/snapshots/test_duedate_post/admin/_language0_project0_subdir0_.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-26T09:00:00+01:00",
+  "due_on": "1485417600",
   "modified_by": "admin",
   "pootle_path": "/language0/project0/subdir0/"
 }

--- a/tests/data/snapshots/test_duedate_post/admin/_language0_project0_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_duedate_post/admin/_language0_project0_subdir0_store4.po.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-26T09:00:00+01:00",
+  "due_on": "1485417600",
   "modified_by": "admin",
   "pootle_path": "/language0/project0/subdir0/store4.po"
 }

--- a/tests/data/snapshots/test_duedate_post/admin/_projects_project0_.context.json
+++ b/tests/data/snapshots/test_duedate_post/admin/_projects_project0_.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-26T09:00:00+01:00",
+  "due_on": "1485417600",
   "modified_by": "admin",
   "pootle_path": "/projects/project0/"
 }

--- a/tests/data/snapshots/test_duedate_post/admin/_projects_project0_store0.po.context.json
+++ b/tests/data/snapshots/test_duedate_post/admin/_projects_project0_store0.po.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-26T09:00:00+01:00",
+  "due_on": "1485417600",
   "modified_by": "admin",
   "pootle_path": "/projects/project0/store0.po"
 }

--- a/tests/data/snapshots/test_duedate_post/admin/_projects_project0_subdir0_.context.json
+++ b/tests/data/snapshots/test_duedate_post/admin/_projects_project0_subdir0_.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-26T09:00:00+01:00",
+  "due_on": "1485417600",
   "modified_by": "admin",
   "pootle_path": "/projects/project0/subdir0/"
 }

--- a/tests/data/snapshots/test_duedate_post/admin/_projects_project0_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_duedate_post/admin/_projects_project0_subdir0_store4.po.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-26T09:00:00+01:00",
+  "due_on": "1485417600",
   "modified_by": "admin",
   "pootle_path": "/projects/project0/subdir0/store4.po"
 }

--- a/tests/data/snapshots/test_duedate_update/admin/_language0_.context.json
+++ b/tests/data/snapshots/test_duedate_update/admin/_language0_.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-27T09:00:00+01:00",
+  "due_on": "1485504000",
   "modified_by": "admin",
   "pootle_path": "/language0/"
 }

--- a/tests/data/snapshots/test_duedate_update/admin/_language0_project0_.context.json
+++ b/tests/data/snapshots/test_duedate_update/admin/_language0_project0_.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-27T09:00:00+01:00",
+  "due_on": "1485504000",
   "modified_by": "admin",
   "pootle_path": "/language0/project0/"
 }

--- a/tests/data/snapshots/test_duedate_update/admin/_language0_project0_store0.po.context.json
+++ b/tests/data/snapshots/test_duedate_update/admin/_language0_project0_store0.po.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-27T09:00:00+01:00",
+  "due_on": "1485504000",
   "modified_by": "admin",
   "pootle_path": "/language0/project0/store0.po"
 }

--- a/tests/data/snapshots/test_duedate_update/admin/_language0_project0_subdir0_.context.json
+++ b/tests/data/snapshots/test_duedate_update/admin/_language0_project0_subdir0_.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-27T09:00:00+01:00",
+  "due_on": "1485504000",
   "modified_by": "admin",
   "pootle_path": "/language0/project0/subdir0/"
 }

--- a/tests/data/snapshots/test_duedate_update/admin/_language0_project0_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_duedate_update/admin/_language0_project0_subdir0_store4.po.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-27T09:00:00+01:00",
+  "due_on": "1485504000",
   "modified_by": "admin",
   "pootle_path": "/language0/project0/subdir0/store4.po"
 }

--- a/tests/data/snapshots/test_duedate_update/admin/_projects_project0_.context.json
+++ b/tests/data/snapshots/test_duedate_update/admin/_projects_project0_.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-27T09:00:00+01:00",
+  "due_on": "1485504000",
   "modified_by": "admin",
   "pootle_path": "/projects/project0/"
 }

--- a/tests/data/snapshots/test_duedate_update/admin/_projects_project0_store0.po.context.json
+++ b/tests/data/snapshots/test_duedate_update/admin/_projects_project0_store0.po.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-27T09:00:00+01:00",
+  "due_on": "1485504000",
   "modified_by": "admin",
   "pootle_path": "/projects/project0/store0.po"
 }

--- a/tests/data/snapshots/test_duedate_update/admin/_projects_project0_subdir0_.context.json
+++ b/tests/data/snapshots/test_duedate_update/admin/_projects_project0_subdir0_.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-27T09:00:00+01:00",
+  "due_on": "1485504000",
   "modified_by": "admin",
   "pootle_path": "/projects/project0/subdir0/"
 }

--- a/tests/data/snapshots/test_duedate_update/admin/_projects_project0_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_duedate_update/admin/_projects_project0_subdir0_store4.po.context.json
@@ -1,5 +1,5 @@
 {
-  "due_on": "2017-01-27T09:00:00+01:00",
+  "due_on": "1485504000",
   "modified_by": "admin",
   "pootle_path": "/projects/project0/subdir0/store4.po"
 }


### PR DESCRIPTION
The JSON encoder now serializes to unix timestamps instead of to ISO strings.