### PR TITLE
TreeItem: refactor cache key retrieval

### DIFF
--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -184,9 +184,6 @@ class Directory(models.Model, CachedTreeItem):
         else:
             return []
 
-    def get_cachekey(self):
-        return self.pootle_path
-
     # # # /TreeItem
 
     def get_relative(self, path):

--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -201,9 +202,6 @@ class Language(models.Model, TreeItem):
 
     def get_children(self):
         return self.translationproject_set.live()
-
-    def get_cachekey(self):
-        return self.directory.pootle_path
 
     # # # /TreeItem
 

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -385,9 +385,6 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
     def get_children(self):
         return self.translationproject_set.live()
 
-    def get_cachekey(self):
-        return self.directory.pootle_path
-
     # # # /TreeItem
 
     def get_stats_for_user(self, user):

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1453,9 +1453,6 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
 
         return parents
 
-    def get_cachekey(self):
-        return self.pootle_path
-
     def _get_wordcount_stats(self):
         """calculate full wordcount statistics"""
         ret = {

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -338,9 +338,6 @@ class TranslationProject(models.Model, CachedTreeItem):
     def get_children(self):
         return self.directory.children
 
-    def get_cachekey(self):
-        return self.pootle_path
-
     def get_parents(self):
         return [self.project]
 

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -81,8 +81,7 @@ class TreeItem(object):
         return []
 
     def get_cachekey(self):
-        """This method will be overridden in descendants"""
-        raise NotImplementedError('`get_cachekey()` not implemented')
+        return self.pootle_path
 
     @classmethod
     def _get_wordcount_stats(cls):

--- a/pootle/core/models/virtualresource.py
+++ b/pootle/core/models/virtualresource.py
@@ -38,7 +38,4 @@ class VirtualResource(TreeItem):
     def get_children(self):
         return self.resources
 
-    def get_cachekey(self):
-        return self.pootle_path
-
     # # # /TreeItem


### PR DESCRIPTION
The key doesn't change across objects, and it's always the internal path.