### PR TITLE
TreeItem: cleanup cache clearing code

### DIFF
--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -264,7 +264,7 @@ class Directory(models.Model, CachedTreeItem):
             return translation_project.real_path + path_prefix
 
     def delete(self, *args, **kwargs):
-        self.clear_all_cache(parents=False, children=False)
+        self.clear_cache()
 
         self.initialize_children()
         for item in self.children:
@@ -281,4 +281,4 @@ class Directory(models.Model, CachedTreeItem):
 
         self.obsolete = True
         self.save()
-        self.clear_all_cache(parents=False, children=False)
+        self.clear_cache()

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1218,7 +1218,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
 
         super(Store, self).delete(*args, **kwargs)
 
-        self.clear_all_cache(parents=False, children=False)
+        self.clear_cache()
         for p in parents:
             p.update_all_cache()
 
@@ -1236,7 +1236,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
         unit_query.update(state=OBSOLETE, index=0)
         self.obsolete = True
         self.save()
-        self.clear_all_cache(parents=False, children=False)
+        self.clear_cache()
 
     def get_absolute_url(self):
         return reverse(

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -382,28 +382,18 @@ class CachedTreeItem(TreeItem):
         """Mark all cached method names for this TreeItem as dirty"""
         self._dirty_cache = set(CachedMethods.get_all())
 
-    def _clear_cache(self, keys, parents=True, children=False):
+    def clear_cache(self):
+        self.mark_all_dirty()
+
         itemkey = self.get_cachekey()
+        keys = self._dirty_cache
         for key in keys:
             cachekey = iri_to_uri(itemkey + ":" + key)
             cache.delete(cachekey)
+
         if keys:
             log("%s deleted from %s cache" % (keys, itemkey))
 
-        if parents:
-            item_parents = self.get_parents()
-            for p in item_parents:
-                p._clear_cache(keys, parents=parents, children=False)
-
-        if children:
-            self.initialize_children()
-            for item in self.children:
-                item._clear_cache(keys, parents=False, children=True)
-
-    def clear_all_cache(self, children=True, parents=True):
-        self.mark_all_dirty()
-        self._clear_cache(self._dirty_cache,
-                          parents=children, children=children)
         self._dirty_cache = set()
 
     # # # # # # #  Update stats in Redis Queue Worker process # # # # # # # #

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -400,14 +400,11 @@ class CachedTreeItem(TreeItem):
             for item in self.children:
                 item._clear_cache(keys, parents=False, children=True)
 
-    def clear_dirty_cache(self, parents=True, children=False):
-        self._clear_cache(self._dirty_cache,
-                          parents=parents, children=children)
-        self._dirty_cache = set()
-
     def clear_all_cache(self, children=True, parents=True):
         self.mark_all_dirty()
-        self.clear_dirty_cache(children=children, parents=parents)
+        self._clear_cache(self._dirty_cache,
+                          parents=children, children=children)
+        self._dirty_cache = set()
 
     # # # # # # #  Update stats in Redis Queue Worker process # # # # # # # #
 


### PR DESCRIPTION
Removes dead code related to clearing the stats cache and consolidates the logic in a single method.