### PR TITLE
TreeItem: items have a single parent

### DIFF
--- a/pootle/apps/pootle_app/models/directory.py
+++ b/pootle/apps/pootle_app/models/directory.py
@@ -169,20 +169,20 @@ class Directory(models.Model, CachedTreeItem):
 
         return result
 
-    def get_parents(self):
-        if self.parent:
-            if self.is_translationproject():
-                return self.translationproject.get_parents()
-            elif self.is_project():
-                return self.project.get_parents()
-            elif self.is_language():
-                return self.language.get_parents()
-            elif self.parent.is_translationproject():
-                return [self.parent.translationproject]
-            else:
-                return [self.parent]
-        else:
-            return []
+    def get_parent(self):
+        if not self.parent:
+            return None
+
+        if self.is_translationproject():
+            return self.translationproject.get_parent()
+        if self.is_project():
+            return self.project.get_parent()
+        if self.is_language():
+            return self.language.get_parent()
+        if self.parent.is_translationproject():
+            return self.parent.translationproject
+
+        return self.parent
 
     # # # /TreeItem
 

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -1206,7 +1206,7 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
             self.update_dirty_cache()
 
     def delete(self, *args, **kwargs):
-        parents = self.get_parents()
+        parent = self.get_parent()
 
         store_log(user='system', action=STORE_DELETED,
                   path=self.pootle_path, store=self.id)
@@ -1219,8 +1219,8 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
         super(Store, self).delete(*args, **kwargs)
 
         self.clear_cache()
-        for p in parents:
-            p.update_all_cache()
+        if parent is not None:
+            parent.update_all_cache()
 
     def makeobsolete(self):
         """Make this store and all its units obsolete."""
@@ -1445,13 +1445,10 @@ class Store(models.Model, CachedTreeItem, base.TranslationStore):
     def can_be_updated(self):
         return not self.obsolete
 
-    def get_parents(self):
+    def get_parent(self):
         if self.parent.is_translationproject():
-            parents = [self.translation_project]
-        else:
-            parents = [self.parent]
-
-        return parents
+            return self.translation_project
+        return self.parent
 
     def _get_wordcount_stats(self):
         """calculate full wordcount statistics"""

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -338,8 +338,8 @@ class TranslationProject(models.Model, CachedTreeItem):
     def get_children(self):
         return self.directory.children
 
-    def get_parents(self):
-        return [self.project]
+    def get_parent(self):
+        return self.project
 
     # # # /TreeItem
 

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -76,9 +76,9 @@ class TreeItem(object):
         self._children = children
         self.initialized = True
 
-    def get_parents(self):
+    def get_parent(self):
         """This method will be overridden in descendants"""
-        return []
+        return None
 
     def get_cachekey(self):
         return self.pootle_path
@@ -494,8 +494,9 @@ class CachedTreeItem(TreeItem):
                     keys_for_parent.remove(key)
 
             if keys_for_parent:
-                for p in self.get_parents():
-                    create_update_cache_job_wrapper(p, keys_for_parent,
+                parent = self.get_parent()
+                if parent is not None:
+                    create_update_cache_job_wrapper(parent, keys_for_parent,
                                                     decrement)
                 self.unregister_dirty(decrement)
             else:

--- a/tests/core/mixins/treeitem.py
+++ b/tests/core/mixins/treeitem.py
@@ -35,28 +35,24 @@ def test_get_children(project0, language0):
 
 
 @pytest.mark.django_db
-def test_get_parents(po_directory, project0, language0, tp0, store0, subdir0):
+def test_get_parent(po_directory, project0, language0, tp0, store0, subdir0):
     """Ensure that retrieved parent objects have a correct type."""
 
     subdir_store = subdir0.child_stores.first()
-    parents = subdir_store.get_parents()
-    assert len(parents) == 1
-    assert isinstance(parents[0], Directory)
+    parent = subdir_store.get_parent()
+    assert isinstance(parent, Directory)
 
-    parents = store0.get_parents()
-    assert len(parents) == 1
-    assert isinstance(parents[0], TranslationProject)
+    parent = store0.get_parent()
+    assert isinstance(parent, TranslationProject)
 
-    parents = tp0.get_parents()
-    assert len(parents) == 1
-    assert isinstance(parents[0], Project)
+    parent = tp0.get_parent()
+    assert isinstance(parent, Project)
 
-    parents = tp0.directory.get_parents()
-    assert len(parents) == 1
-    assert isinstance(parents[0], Project)
+    parent = tp0.directory.get_parent()
+    assert isinstance(parent, Project)
 
-    parents = project0.directory.get_parents()
-    assert len(parents) == 0
+    parent = project0.directory.get_parent()
+    assert parent is None
 
-    parents = language0.directory.get_parents()
-    assert len(parents) == 0
+    parent = language0.directory.get_parent()
+    assert parent is None


### PR DESCRIPTION
This commit renames the `get_parents()` method into `get_parent()` and
returns individual objects instead of lists of objects. Likewise, `None`
is returned for the situation where there are no parents for an item.

Note this very same change was already performed in the past (82740dd),
but the change was reverted to support virtual folders (7a66eae).