### PR TITLE
Contact form: fix subject line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ v0.3.1 (in development)
 
 * Fixed reference in static pages which prevented the editor from showing up.
 * Removed unused `clear_stats` command. Use `flush_cache --stats` instead (#197).
+* Fixed subject line for emails sent via the contact form (#203).
 
 
 v0.3.0 (2017-02-06)

--- a/pootle/apps/contact/forms.py
+++ b/pootle/apps/contact/forms.py
@@ -21,10 +21,10 @@ from pootle.core.mail import send_mail
 class ContactForm(MathCaptchaForm, OriginalContactForm):
 
     field_order = [
-        'name', 'email', 'subject', 'body', 'captcha_answer', 'captcha_token',
+        'name', 'email', 'summary', 'body', 'captcha_answer', 'captcha_token',
     ]
 
-    subject = forms.CharField(
+    summary = forms.CharField(
         max_length=100,
         label=_(u'Summary'),
         widget=forms.TextInput(
@@ -109,7 +109,7 @@ class ReportForm(ContactForm):
     """Contact form used to report errors on strings."""
 
     field_order = [
-        'name', 'email', 'subject', 'body', 'captcha_answer',
+        'name', 'email', 'summary', 'body', 'captcha_answer',
         'captcha_token', 'report_email',
     ]
 

--- a/pootle/apps/contact/forms.py
+++ b/pootle/apps/contact/forms.py
@@ -9,6 +9,7 @@
 
 from django import forms
 from django.conf import settings
+from django.template import loader
 from django.utils.translation import ugettext_lazy as _
 
 from contact_form.forms import ContactForm as OriginalContactForm
@@ -49,6 +50,40 @@ class ContactForm(MathCaptchaForm, OriginalContactForm):
         if self.request.user.is_authenticated:
             del self.fields['captcha_answer']
             del self.fields['captcha_token']
+
+    def message(self):
+        """Render the body of the message to a string.
+
+        FIXME: this copies and adjusts upstream code to support Django 1.10+.
+        Remove once django-contact-form is fixed.
+        """
+        if callable(self.template_name):
+            template_name = self.template_name()
+        else:
+            template_name = self.template_name
+        return loader.render_to_string(template_name,
+                                       context=self.get_context(),
+                                       request=self.request)
+
+    def subject(self):
+        """Render the subject of the message to a string.
+
+        FIXME: this copies and adjusts upstream code to support Django 1.10+.
+        Remove once django-contact-form is fixed.
+        """
+        template_name = self.subject_template_name() if \
+            callable(self.subject_template_name) \
+            else self.subject_template_name
+        subject = loader.render_to_string(template_name,
+                                          context=self.get_context(),
+                                          request=self.request)
+        return ''.join(subject.splitlines())
+
+    def get_context(self):
+        """FIXME: this copies and adjusts upstream code to support Django 1.10+.
+        Remove once django-contact-form is fixed.
+        """
+        return dict(self.cleaned_data)
 
     def from_email(self):
         return u'%s <%s>' % (

--- a/pootle/apps/contact/forms.py
+++ b/pootle/apps/contact/forms.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
-
-from collections import OrderedDict
 
 from django import forms
 from django.conf import settings
@@ -19,6 +18,10 @@ from pootle.core.mail import send_mail
 
 
 class ContactForm(MathCaptchaForm, OriginalContactForm):
+
+    field_order = [
+        'name', 'email', 'subject', 'body', 'captcha_answer', 'captcha_token',
+    ]
 
     subject = forms.CharField(
         max_length=100,
@@ -67,16 +70,13 @@ class ContactForm(MathCaptchaForm, OriginalContactForm):
         send_mail(fail_silently=fail_silently, **kwargs)
 
 
-# Alters form's field order. Use `self.field_order` when in Django 1.9+
-ContactForm.base_fields = OrderedDict(
-    (f, ContactForm.base_fields[f])
-    for f in ['name', 'email', 'subject', 'body', 'captcha_answer',
-              'captcha_token']
-)
-
-
 class ReportForm(ContactForm):
     """Contact form used to report errors on strings."""
+
+    field_order = [
+        'name', 'email', 'subject', 'body', 'captcha_answer',
+        'captcha_token', 'report_email',
+    ]
 
     report_email = forms.EmailField(
         max_length=254,
@@ -95,10 +95,3 @@ class ReportForm(ContactForm):
         report_email = getattr(settings, 'POOTLE_CONTACT_REPORT_EMAIL',
                                settings.POOTLE_CONTACT_EMAIL)
         return [report_email]
-
-# Alters form's field order. Use `self.field_order` when in Django 1.9+
-ReportForm.base_fields = OrderedDict(
-    (f, ReportForm.base_fields[f])
-    for f in ['name', 'email', 'subject', 'body', 'captcha_answer',
-              'captcha_token', 'report_email']
-)

--- a/pootle/apps/contact/views.py
+++ b/pootle/apps/contact/views.py
@@ -85,7 +85,7 @@ class ReportFormView(ContactFormView):
                     unit_absolute_url = self.request.build_absolute_uri(
                         unit.get_translate_url())
                     initial.update({
-                        'subject': render_to_string(
+                        'summary': render_to_string(
                             'contact_form/report_form_subject.txt',
                             context={
                                 'unit': unit,

--- a/pootle/templates/contact_form/contact_form_subject.txt
+++ b/pootle/templates/contact_form/contact_form_subject.txt
@@ -1,1 +1,1 @@
-[{{ settings.POOTLE_TITLE }}] {{ subject }}
+[{{ settings.POOTLE_TITLE }}] {{ summary }}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ Django~=1.10.5  # rq.filter: <1.11
 # Django apps
 django-allauth==0.30.0
 django-assets==0.12
-django-contact-form==1.2
+django-contact-form==1.3
 django-contrib-comments==1.7.3
 django-overextends==0.4.2
 django-redis==4.5.0


### PR DESCRIPTION
This PR fixes the subject line for emails sent via the contact form. Unfortunately this is caused by the incomplete Django 1.10 support of django-contact-form, so some extra code had to be brought to work around that.