### PR TITLE
JSONEncoder: return timestamps as integers

### DIFF
--- a/pootle/core/utils/json.py
+++ b/pootle/core/utils/json.py
@@ -36,7 +36,7 @@ class PootleJSONEncoder(DjangoJSONEncoder):
         if (isinstance(obj, datetime.datetime) or
             isinstance(obj, datetime.date) or
             isinstance(obj, datetime.time)):
-            return dateformat.format(obj, 'U')
+            return int(dateformat.format(obj, 'U'))
 
         try:
             return super(PootleJSONEncoder, self).default(obj)


### PR DESCRIPTION
This is what client-side code expects.