### PR TITLE
Stats: provide a simple way to retrieve stats by path

### DIFF
--- a/pootle/models/__init__.py
+++ b/pootle/models/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Zing contributors.
+#
+# This file is a part of the Zing project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from .stats import Stats
+
+
+__all__ = ('Stats',)

--- a/pootle/models/stats.py
+++ b/pootle/models/stats.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Zing contributors.
+#
+# This file is a part of the Zing project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import logging
+
+from django.utils.encoding import iri_to_uri
+
+from django_rq.queues import get_connection
+
+from pootle.core.cache import get_cache
+from pootle.core.mixins.treeitem import CachedMethods
+
+
+logger = logging.getLogger('stats')
+cache = get_cache('stats')
+
+
+class Stats(object):
+    """Retrieves stats directly from the cache.
+
+    This is a basic, standalone, and lightweight version of the implementation
+    available in `CachedTreeItem` and is limited to paths which mixin with this
+    class. It also doesn't account for children stats.
+    """
+
+    def __init__(self, path, *args, **kwargs):
+        self.path = path
+        self.r_con = get_connection()
+
+    @property
+    def total(self):
+        return self.get_wordcount()['total']
+
+    @property
+    def translated(self):
+        return self.get_wordcount()['translated']
+
+    @property
+    def fuzzy(self):
+        return self.get_wordcount()['fuzzy']
+
+    @property
+    def incomplete(self):
+        try:
+            return self.total - self.translated
+        except TypeError:
+            return None
+
+    @property
+    def critical(self):
+        check_stats = self.get_value(CachedMethods.CHECKS, {})
+        return check_stats.get('unit_critical_error_count', None)
+
+    @property
+    def suggestions(self):
+        return self.get_value(CachedMethods.SUGGESTIONS)
+
+    @property
+    def last_action(self):
+        return self.get_value(CachedMethods.LAST_ACTION)
+
+    @property
+    def last_updated(self):
+        return self.get_value(CachedMethods.LAST_UPDATED)
+
+    def make_cache_key(self, name):
+        return iri_to_uri('%s:%s' % (self.path, name))
+
+    def get_value(self, name, default=None):
+        """get stat value from cache"""
+        key = self.make_cache_key(name)
+        result = cache.get(key)
+        if result is None:
+            logger.debug(u'Cache miss %s for %s', name, key)
+            return default
+
+        return result
+
+    def get_wordcount(self):
+        return self.get_value(CachedMethods.WORDCOUNT_STATS, {
+            'total': None,
+            'translated': None,
+            'fuzzy': None,
+        })

--- a/pytest_pootle/plugin.py
+++ b/pytest_pootle/plugin.py
@@ -132,7 +132,7 @@ def django_db_use_migrations(tests_use_migration):
 @pytest.fixture
 def test_name(request):
     """Provides current test function's name as a string."""
-    return request.node.originalname
+    return request.node.originalname or request.node.name
 
 
 pytest_plugins = tuple(

--- a/tests/data/snapshots/test_stats_retrieval/_language0_project0_.json
+++ b/tests/data/snapshots/test_stats_retrieval/_language0_project0_.json
@@ -1,0 +1,19 @@
+{
+  "critical": 9,
+  "fuzzy": 370,
+  "incomplete": 838,
+  "last_action": {
+    "displayname": "Member",
+    "email": "d41d8cd98f00b204e9800998ecf8427e",
+    "mtime": 1483361146,
+    "source": "Translated Source /language0/project0/store2.po...",
+    "translation_action_type": 1,
+    "type": 1,
+    "uid": 19,
+    "username": "member"
+  },
+  "last_updated": 1484570757,
+  "suggestions": 27,
+  "total": 1320,
+  "translated": 482
+}

--- a/tests/data/snapshots/test_stats_retrieval_dummy/_non_existing_.json
+++ b/tests/data/snapshots/test_stats_retrieval_dummy/_non_existing_.json
@@ -1,0 +1,10 @@
+{
+  "critical": null,
+  "fuzzy": null,
+  "incomplete": null,
+  "last_action": null,
+  "last_updated": null,
+  "suggestions": null,
+  "total": null,
+  "translated": null
+}

--- a/tests/data/snapshots/test_stats_retrieval_no_stats/_language0_project0_.json
+++ b/tests/data/snapshots/test_stats_retrieval_no_stats/_language0_project0_.json
@@ -1,0 +1,10 @@
+{
+  "critical": null,
+  "fuzzy": null,
+  "incomplete": null,
+  "last_action": null,
+  "last_updated": null,
+  "suggestions": null,
+  "total": null,
+  "translated": null
+}

--- a/tests/models/stats.py
+++ b/tests/models/stats.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Zing contributors.
+#
+# This file is a part of the Zing project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+import pytest
+
+from pytest_pootle.utils import as_dir, url_name
+
+from pootle.models import Stats
+
+
+@pytest.mark.django_db
+def test_stats_retrieval(test_name, snapshot_stack, refresh_stats):
+    """Tests stats values are retrieved properly."""
+    path = '/language0/project0/'
+    with snapshot_stack.push([as_dir(test_name), url_name(path)]) as snapshot:
+        stats = Stats(path)
+        stats_data = {
+            'total': stats.total,
+            'translated': stats.translated,
+            'fuzzy': stats.fuzzy,
+            'incomplete': stats.incomplete,
+            'critical': stats.critical,
+            'suggestions': stats.suggestions,
+            'last_action': stats.last_action,
+            'last_updated': stats.last_updated,
+        }
+        snapshot.assert_matches(stats_data)
+
+
+@pytest.mark.django_db
+def test_stats_retrieval_dummy(test_name, snapshot_stack, refresh_stats):
+    """Tests no stats are provided for dummy paths."""
+    path = '/non/existing/'
+    with snapshot_stack.push([as_dir(test_name), url_name(path)]) as snapshot:
+        stats = Stats(path)
+        stats_data = {
+            'total': stats.total,
+            'translated': stats.translated,
+            'fuzzy': stats.fuzzy,
+            'incomplete': stats.incomplete,
+            'critical': stats.critical,
+            'suggestions': stats.suggestions,
+            'last_action': stats.last_action,
+            'last_updated': stats.last_updated,
+        }
+        snapshot.assert_matches(stats_data)
+
+
+@pytest.mark.django_db
+def test_stats_retrieval_no_stats(test_name, snapshot_stack, flush_stats):
+    """Tests no stats are provided when these haven't been calculated."""
+    path = '/language0/project0/'
+    with snapshot_stack.push([as_dir(test_name), url_name(path)]) as snapshot:
+        stats = Stats(path)
+        stats_data = {
+            'total': stats.total,
+            'translated': stats.translated,
+            'fuzzy': stats.fuzzy,
+            'incomplete': stats.incomplete,
+            'critical': stats.critical,
+            'suggestions': stats.suggestions,
+            'last_action': stats.last_action,
+            'last_updated': stats.last_updated,
+        }
+        snapshot.assert_matches(stats_data)


### PR DESCRIPTION
This PR implements a lightweight `Stats` class for easy querying of stats by path, e.g.:
```python
>> stats = Stats('/foo/bar/')
>> stats.total
14794
>> stats.fuzzy
0
>> stats.last_updated
1485306937
```