### PR TITLE
Due dates: propagate project changes to TPs

### DIFF
--- a/pootle/models/duedate.py
+++ b/pootle/models/duedate.py
@@ -6,17 +6,30 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import re
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils.functional import cached_property
 
 from pootle.core.url_helpers import split_pootle_path
+from pootle_translationproject.models import TranslationProject
 
 
 def validate_pootle_path(value):
     project_code = split_pootle_path(value)[1]
     if project_code is None:
         raise ValidationError('Cannot set due date for this path.')
+
+
+class DueDateManager(models.Manager):
+
+    def for_project(self, project_code):
+        """Retrieves a queryset of due dates available for `project_code`."""
+        return self.get_queryset().filter(
+            pootle_path__regex=r'^/[^/]*/%s/' % project_code
+        )
 
 
 class DueDate(models.Model):
@@ -27,6 +40,20 @@ class DueDate(models.Model):
     modified_by = models.ForeignKey(settings.AUTH_USER_MODEL)
     modified_on = models.DateTimeField(auto_now_add=True)
 
+    objects = DueDateManager()
+
+    @cached_property
+    def path_parts(self):
+        return split_pootle_path(self.pootle_path)
+
+    @property
+    def language_code(self):
+        return self.path_parts[0]
+
+    @property
+    def project_code(self):
+        return self.path_parts[1]
+
     def __unicode__(self):
         return u'<DueDate: %s>' % (self.due_on)
 
@@ -34,3 +61,44 @@ class DueDate(models.Model):
         self.full_clean()
 
         super(DueDate, self).save(*args, **kwargs)
+
+        if self.language_code is not None:
+            return
+
+        # The due date refers to a project: propagate changes to TPs
+        existing_due_dates = DueDate.objects.for_project(self.project_code)
+        existing_due_dates.update(
+            due_on=self.due_on,
+            modified_by=self.modified_by,
+            modified_on=self.modified_on,
+        )
+        processed_languages = [
+            due_date.language_code
+            for due_date in existing_due_dates
+            if due_date.language_code is not None
+        ]
+
+        project_languages = TranslationProject.objects.filter(
+            project__code=self.project_code,
+        ).values_list('language__code', flat=True)
+
+        DueDate.objects.bulk_create(
+            DueDate(
+                pootle_path=re.sub(
+                    r'^/projects/', '/%s/' % language, self.pootle_path,
+                ),
+                due_on=self.due_on,
+                modified_by=self.modified_by,
+                modified_on=self.modified_on,
+            )
+            for language in project_languages
+            if language not in processed_languages
+        )
+
+    def delete(self, *args, **kwargs):
+        super(DueDate, self).delete(*args, **kwargs)
+
+        if self.language_code is not None:
+            return
+
+        DueDate.objects.for_project(self.project_code).delete()

--- a/pytest_pootle/factories.py
+++ b/pytest_pootle/factories.py
@@ -223,6 +223,8 @@ class SuggestionFactory(factory.django.DjangoModelFactory):
 
 
 class DueDateFactory(factory.django.DjangoModelFactory):
+    due_on = timezone.now()
+    modified_by = factory.SubFactory(UserFactory)
 
-        class Meta(object):
-            model = 'pootle.DueDate'
+    class Meta(object):
+        model = 'pootle.DueDate'

--- a/tests/models/duedate.py
+++ b/tests/models/duedate.py
@@ -9,11 +9,12 @@
 import pytest
 
 from django.core.exceptions import ValidationError
-from django.utils import timezone
 
-from pytest_pootle.factories import DueDateFactory
+from pytest_pootle.factories import DueDateFactory, UserFactory
 
+from pootle.core.utils.timezone import aware_datetime
 from pootle.models import DueDate
+from pootle_translationproject.models import TranslationProject
 
 
 @pytest.mark.django_db
@@ -47,3 +48,73 @@ def test_duedate_create(pootle_path):
         pootle_path=pootle_path,
     )
     assert due_date.id is not None
+
+
+@pytest.mark.django_db
+def test_duedate_create_project_propagates():
+    """Tests due date creation at the project level propagates to
+    existing TPs.
+    """
+    project_code = 'project0'
+    pootle_path = '/projects/%s/' % project_code
+    DueDateFactory.create(
+        pootle_path=pootle_path,
+    )
+
+    tp_due_dates = DueDate.objects.for_project(project_code).exclude(
+        pootle_path__startswith=pootle_path,
+    )
+    tps = TranslationProject.objects.filter(project__code=project_code)
+    assert tp_due_dates.count() == tps.count() != 0
+
+
+@pytest.mark.django_db
+def test_duedate_update_project_propagates():
+    """Tests due date updates at the project level propagates to
+    existing TP due dates.
+    """
+    project_code = 'project0'
+    pootle_path = '/projects/%s/' % project_code
+    due_date = DueDateFactory.create(
+        pootle_path=pootle_path,
+    )
+
+    # Update due date with different values
+    other_user = UserFactory.create()
+    other_due_on = aware_datetime(2017, 1, 1, 1, 2, 3)
+    due_date.due_on = other_due_on
+    due_date.modified_by = other_user
+    due_date.save()
+
+    tp_due_dates = DueDate.objects.for_project(project_code).exclude(
+        pootle_path__startswith=pootle_path,
+    )
+    for tp_due_date in tp_due_dates:
+        assert tp_due_date.due_on == other_due_on
+        assert tp_due_date.modified_by == other_user
+
+
+@pytest.mark.django_db
+def test_duedate_delete_project_propagates():
+    """Tests due date deletion at the project level propagates to
+    existing TP due dates.
+    """
+    project_code = 'project0'
+    pootle_path = '/projects/%s/' % project_code
+    due_date = DueDateFactory.create(
+        pootle_path=pootle_path,
+    )
+
+    tp_due_dates = DueDate.objects.for_project(project_code).exclude(
+        pootle_path__startswith=pootle_path,
+    )
+    tps = TranslationProject.objects.filter(project__code=project_code)
+    assert tp_due_dates.count() == tps.count() != 0
+
+    due_date.delete()
+
+    tp_due_dates = DueDate.objects.for_project(project_code).exclude(
+        pootle_path__startswith=pootle_path,
+    )
+
+    assert tp_due_dates.count() == 0

--- a/tests/models/duedate.py
+++ b/tests/models/duedate.py
@@ -11,7 +11,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
-from pytest_pootle.factories import UserFactory
+from pytest_pootle.factories import DueDateFactory
 
 from pootle.models import DueDate
 
@@ -25,7 +25,7 @@ from pootle.models import DueDate
 def test_duedate_create_invalid_paths(pootle_path):
     """Tests certain path restrictions when creating due dates."""
     with pytest.raises(ValidationError) as excinfo:
-        DueDate.objects.create(pootle_path=pootle_path)
+        DueDateFactory.create(pootle_path=pootle_path)
 
     message_dict = excinfo.value.message_dict
     assert 'pootle_path' in message_dict
@@ -43,12 +43,7 @@ def test_duedate_create_invalid_paths(pootle_path):
 ])
 def test_duedate_create(pootle_path):
     """Tests due dates creation for valid paths."""
-    user = UserFactory.create()
-    due_on = timezone.now()
-
-    due_date = DueDate.objects.create(
-        due_on=due_on,
-        modified_by=user,
+    due_date = DueDateFactory.create(
         pootle_path=pootle_path,
     )
     assert due_date.id is not None


### PR DESCRIPTION
When creating/updating/deleting a due date at the project level, the
operation will affect all existing TPs that belong to the project, which
means that these will take over any language-specific due dates that
might have existed before.

This change will also considerably improve querying due dates for
particular languages.