### PR TITLE
URL utils: implement internal path split utility

### DIFF
--- a/pootle/static/js/shared/utils/url.js
+++ b/pootle/static/js/shared/utils/url.js
@@ -6,6 +6,57 @@
  * AUTHORS file for copyright and authorship information.
  */
 
+/**
+ * Split a string while returning the remainder.
+ *
+ * Note JS's `String.prototype.split` method unfortunately doesn't
+ * return the remainder in the last index in case a limit parameter
+ * was specified.
+ */
+export function split(value, separator, limit) {
+  const parts = value.split(separator);
+
+  if (parts.length <= limit) {
+    return parts;
+  }
+  return parts.splice(0, limit).concat(parts.join(separator));
+}
+
+
+/**
+ * Splits an internal path into language, project, directory and file parts.
+ * @param {string} path - internal path
+ * @return {array} - [lang_code, proj_code, dir_path, filename]
+ */
+export function splitPootlePath(path) {
+  const slashCount = path.split('/').length - 1;
+  const parts = split(path, '/', 3).slice(1);
+
+  let languageCode = null;
+  let projectCode = null;
+  let ctx = '';
+
+  if (slashCount !== 0 && path !== '/projects/') {
+    if (slashCount === 2) {
+      languageCode = parts[0];
+    // FIXME: use `.startsWith()` after dropping IE11 support
+    } else if (/^\/projects\//.test(path)) {
+      projectCode = parts[1];
+      ctx = parts[2];
+    } else if (slashCount !== 1) {
+      languageCode = parts[0];
+      projectCode = parts[1];
+      ctx = parts[2];
+    }
+  }
+
+  const lastSlash = ctx.lastIndexOf('/');
+  const dirPath = ctx.substring(0, lastSlash + 1);
+  const filename = ctx.substring(lastSlash + 1, ctx.length);
+
+  return [languageCode, projectCode, dirPath, filename];
+}
+
 
 /**
  * Retrieves a translation URL out of an internal `path`

--- a/pootle/static/js/shared/utils/url.test.js
+++ b/pootle/static/js/shared/utils/url.test.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) Zing contributors.
+ *
+ * This file is a part of the Zing project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import expect from 'expect';
+import { describe, it } from 'mocha';
+
+import { split, splitPootlePath } from './url';
+
+
+describe('url', () => {
+  describe('split', () => {
+    it('returns the remainder after a split', () => {
+      expect(
+        split('/foo/bar/baz/blah/', '/', 2)
+      ).toEqual(['', 'foo', 'bar/baz/blah/']);
+    });
+  });
+
+  describe('splitPootlePath', () => {
+    it('handles empty paths', () => {
+      expect(splitPootlePath('')).toEqual([null, null, '', '']);
+    });
+
+    it('handles root paths', () => {
+      expect(splitPootlePath('/')).toEqual([null, null, '', '']);
+    });
+
+    it('handles empty project paths', () => {
+      expect(splitPootlePath('/projects/')).toEqual([null, null, '', '']);
+    });
+
+    it('splits language paths', () => {
+      expect(splitPootlePath('/ru/')).toEqual(['ru', null, '', '']);
+    });
+
+    it('splits project paths', () => {
+      expect(splitPootlePath('/projects/foo/')).toEqual([null, 'foo', '', '']);
+    });
+
+    it('splits translation project paths', () => {
+      expect(splitPootlePath('/ru/foo/')).toEqual(['ru', 'foo', '', '']);
+    });
+
+    it('splits TP-level directories', () => {
+      const tests = [
+        {
+          path: '/ru/foo/bar/',
+          expected: ['ru', 'foo', 'bar/', ''],
+        },
+        {
+          path: '/ru/foo/bar/baz/',
+          expected: ['ru', 'foo', 'bar/baz/', ''],
+        },
+      ];
+      tests.forEach(test => {
+        expect(splitPootlePath(test.path)).toEqual(test.expected);
+      });
+    });
+
+    it('splits project-level directories', () => {
+      const tests = [
+        {
+          path: '/projects/foo/bar/',
+          expected: [null, 'foo', 'bar/', ''],
+        },
+        {
+          path: '/projects/foo/bar/baz/',
+          expected: [null, 'foo', 'bar/baz/', ''],
+        },
+      ];
+      tests.forEach(test => {
+        expect(splitPootlePath(test.path)).toEqual(test.expected);
+      });
+    });
+
+    it('splits TP-level files', () => {
+      const tests = [
+        {
+          path: '/ru/foo/bar',
+          expected: ['ru', 'foo', '', 'bar'],
+        },
+        {
+          path: '/ru/foo/bar.po',
+          expected: ['ru', 'foo', '', 'bar.po'],
+        },
+        {
+          path: '/ru/foo/bar/baz',
+          expected: ['ru', 'foo', 'bar/', 'baz'],
+        },
+        {
+          path: '/ru/foo/bar/baz/blah.po',
+          expected: ['ru', 'foo', 'bar/baz/', 'blah.po'],
+        },
+        {
+          path: '/ru/foo/bar/baz.po',
+          expected: ['ru', 'foo', 'bar/', 'baz.po'],
+        },
+      ];
+      tests.forEach(test => {
+        expect(splitPootlePath(test.path)).toEqual(test.expected);
+      });
+    });
+
+    it('splits project-level files', () => {
+      const tests = [
+        {
+          path: '/projects/foo/bar',
+          expected: [null, 'foo', '', 'bar'],
+        },
+        {
+          path: '/projects/foo/bar.po',
+          expected: [null, 'foo', '', 'bar.po'],
+        },
+        {
+          path: '/projects/foo/bar/baz',
+          expected: [null, 'foo', 'bar/', 'baz'],
+        },
+        {
+          path: '/projects/foo/bar/baz/blah.po',
+          expected: [null, 'foo', 'bar/baz/', 'blah.po'],
+        },
+        {
+          path: '/projects/foo/bar/baz.po',
+          expected: [null, 'foo', 'bar/', 'baz.po'],
+        },
+      ];
+      tests.forEach(test => {
+        expect(splitPootlePath(test.path)).toEqual(test.expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This is a port of the backend's path splitting function so we can use it
to easily and reliably split internal paths into manageable parts, which
can then be leveraged for path and URL generation purposes.