### PR TITLE
Due dates: ensure propagation only affects current resources

### DIFF
--- a/tests/models/duedate.py
+++ b/tests/models/duedate.py
@@ -14,6 +14,7 @@ from pytest_pootle.factories import DueDateFactory, UserFactory
 
 from pootle.core.utils.timezone import aware_datetime
 from pootle.models import DueDate
+from pootle_store.models import Store
 from pootle_translationproject.models import TranslationProject
 
 
@@ -53,16 +54,30 @@ def test_duedate_create(pootle_path):
 @pytest.mark.django_db
 def test_duedate_create_project_propagates():
     """Tests due date creation at the project level propagates to
-    existing TPs.
+    existing resources.
     """
     project_code = 'project0'
-    pootle_path = '/projects/%s/' % project_code
+
+    store_path = '/projects/%s/store0.po' % project_code
     DueDateFactory.create(
-        pootle_path=pootle_path,
+        pootle_path=store_path,
     )
 
-    tp_due_dates = DueDate.objects.for_project(project_code).exclude(
-        pootle_path__startswith=pootle_path,
+    store_due_dates = DueDate.objects.for_project_path(store_path).exclude(
+        pootle_path=store_path,
+    )
+    stores = Store.objects.filter(
+        pootle_path__endswith='/%s/store0.po' % project_code,
+    )
+    assert store_due_dates.count() == stores.count() != 0
+
+    project_path = '/projects/%s/' % project_code
+    DueDateFactory.create(
+        pootle_path=project_path,
+    )
+
+    tp_due_dates = DueDate.objects.for_project_path(project_path).exclude(
+        pootle_path=project_path,
     )
     tps = TranslationProject.objects.filter(project__code=project_code)
     assert tp_due_dates.count() == tps.count() != 0
@@ -70,13 +85,19 @@ def test_duedate_create_project_propagates():
 
 @pytest.mark.django_db
 def test_duedate_update_project_propagates():
-    """Tests due date updates at the project level propagates to
-    existing TP due dates.
+    """Tests due date updates at the project level propagate to
+    existing due dates that point to the same resource across languages.
     """
     project_code = 'project0'
-    pootle_path = '/projects/%s/' % project_code
+
+    store_path = '/projects/%s/store0.po' % project_code
+    DueDateFactory.create(
+        pootle_path=store_path,
+    )
+
+    project_path = '/projects/%s/' % project_code
     due_date = DueDateFactory.create(
-        pootle_path=pootle_path,
+        pootle_path=project_path,
     )
 
     # Update due date with different values
@@ -86,35 +107,65 @@ def test_duedate_update_project_propagates():
     due_date.modified_by = other_user
     due_date.save()
 
-    tp_due_dates = DueDate.objects.for_project(project_code).exclude(
-        pootle_path__startswith=pootle_path,
+    tp_due_dates = DueDate.objects.for_project_path(project_path).exclude(
+        pootle_path=project_path,
     )
     for tp_due_date in tp_due_dates:
         assert tp_due_date.due_on == other_due_on
         assert tp_due_date.modified_by == other_user
 
+    # Ensure the other due dates haven't been modified
+    store_due_dates = DueDate.objects.for_project_path(store_path).exclude(
+        pootle_path=store_path,
+    )
+    for store_due_date in store_due_dates:
+        assert store_due_date.due_on != other_due_on
+        assert store_due_date.modified_by != other_user
+
 
 @pytest.mark.django_db
 def test_duedate_delete_project_propagates():
-    """Tests due date deletion at the project level propagates to
-    existing TP due dates.
+    """Tests due date deletion at the project level propagate to
+    existing due dates that point to the same resource across languages.
     """
     project_code = 'project0'
-    pootle_path = '/projects/%s/' % project_code
-    due_date = DueDateFactory.create(
-        pootle_path=pootle_path,
+
+    store_path = '/projects/%s/store0.po' % project_code
+    DueDateFactory.create(
+        pootle_path=store_path,
     )
 
-    tp_due_dates = DueDate.objects.for_project(project_code).exclude(
-        pootle_path__startswith=pootle_path,
+    project_path = '/projects/%s/' % project_code
+    due_date = DueDateFactory.create(
+        pootle_path=project_path,
+    )
+
+    tp_due_dates = DueDate.objects.for_project_path(project_path).exclude(
+        pootle_path=project_path,
     )
     tps = TranslationProject.objects.filter(project__code=project_code)
     assert tp_due_dates.count() == tps.count() != 0
 
     due_date.delete()
 
-    tp_due_dates = DueDate.objects.for_project(project_code).exclude(
-        pootle_path__startswith=pootle_path,
+    tp_due_dates = DueDate.objects.for_project_path(project_path).exclude(
+        pootle_path=project_path,
     )
-
     assert tp_due_dates.count() == 0
+
+    store_due_dates = DueDate.objects.for_project_path(store_path).exclude(
+        pootle_path=store_path,
+    )
+    assert store_due_dates.count() != 0
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('dummy_path', [
+    '/language0/project0/',
+    '/foo/bar/',
+    '/foo/bar/baz/',
+])
+def test_duedate_manager_for_project_path(dummy_path):
+    """Tests the manager method does nothing for non-project paths."""
+    DueDateFactory.create(pootle_path=dummy_path)
+    assert DueDate.objects.for_project_path(dummy_path).count() == 0


### PR DESCRIPTION
The previous was buggy as it would update/delete due dates for all
resources in a TP.