### PR TITLE
Due dates: refresh list of pending tasks upon modifications

### DIFF
--- a/pootle/forms/task.py
+++ b/pootle/forms/task.py
@@ -11,6 +11,9 @@ from django import forms
 from pootle_language.models import Language
 
 
+PENDING_TASKS_LIMIT = 5
+
+
 class GetTaskForm(forms.Form):
 
     language = forms.ModelChoiceField(
@@ -18,6 +21,14 @@ class GetTaskForm(forms.Form):
         to_field_name='code',
     )
     offset = forms.IntegerField(required=False)
+    limit = forms.IntegerField(required=False)
 
     def clean_offset(self):
-        return self.cleaned_data.get('offset', 0) or 0
+        return self.cleaned_data.get('offset') or 0
+
+    def clean_limit(self):
+        limit = self.cleaned_data.get('limit') or PENDING_TASKS_LIMIT
+        # Allow at max 2 times the limit of tasks. This can be useful
+        # when the tasks list is expanded to more than `PENDING_TASKS_LIMIT`
+        # items and we want to refresh the existing items right away.
+        return min(limit, 2 * PENDING_TASKS_LIMIT)

--- a/pootle/static/js/admin/duedates/components/DueDateContainer.js
+++ b/pootle/static/js/admin/duedates/components/DueDateContainer.js
@@ -32,7 +32,7 @@ class DueDateContainer extends React.Component {
       .then(() => this.setState({
         id: null,
         dueOn: 0,
-      }));
+      }, this.handlePostUpdate));
   }
 
   handleUpdate(isoDate) {
@@ -47,8 +47,13 @@ class DueDateContainer extends React.Component {
       this.setState(() => ({
         id: dueDate.id,
         dueOn: dueDate.due_on,
-      }));
+      }), this.handlePostUpdate);
     });
+  }
+
+  handlePostUpdate() {
+    // FIXME: dirty but okayish for now
+    PTL.stats.refreshTasks();
   }
 
   render() {

--- a/pootle/static/js/browser/components/PendingTaskContainer.js
+++ b/pootle/static/js/browser/components/PendingTaskContainer.js
@@ -24,6 +24,12 @@ class PendingTaskContainer extends React.Component {
     };
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.hasOwnProperty('tasks')) {
+      this.setState({ tasks: nextProps.tasks });
+    }
+  }
+
   handleLoadMore(e) {
     e.preventDefault();
 

--- a/pootle/static/js/shared/api/TaskAPI.js
+++ b/pootle/static/js/shared/api/TaskAPI.js
@@ -13,11 +13,24 @@ const TaskAPI = {
 
   apiRoot: '/xhr/tasks/',
 
-  get(languageCode, { offset = 0 } = {}) {
+  get(languageCode, { offset = 0, limit = 0 } = {}) {
     let url = `${this.apiRoot}${languageCode}/`;
+    const params = {};
+
     if (offset > 0) {
-      url = `${url}?offset=${offset}`;
+      params.offset = offset;
     }
+    if (limit > 0) {
+      params.limit = limit;
+    }
+
+    const qs = Object.keys(params).map(
+      key => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`
+    ).join('&');
+    if (qs) {
+      url = `${url}?${qs}`;
+    }
+
     return fetch({ url });
   },
 

--- a/pootle/static/js/stats.js
+++ b/pootle/static/js/stats.js
@@ -15,6 +15,7 @@ import 'jquery-utils';
 import assign from 'object-assign';
 
 import StatsAPI from 'api/StatsAPI';
+import TaskAPI from 'api/TaskAPI';
 import LastActivity from 'components/LastActivity';
 import TimeSince from 'components/TimeSince';
 import { q } from 'utils/dom';
@@ -136,14 +137,7 @@ const stats = {
     });
 
     if (options.pendingTasks) {
-      ReactDOM.render(
-        <PendingTaskContainer
-          languageCode={options.languageCode}
-          tasks={options.pendingTasks.items}
-          total={options.pendingTasks.total}
-        />,
-        q('.js-mnt-pending-tasks')
-      );
+      this.setTasks(options.pendingTasks.items, options.pendingTasks.total);
     }
 
     ReactDOM.render(
@@ -180,6 +174,26 @@ const stats = {
         {}
     );
     this.updateUI();
+  },
+
+  setTasks(tasks, total) {
+    this.taskContainer = ReactDOM.render(
+      <PendingTaskContainer
+        languageCode={this.languageCode}
+        tasks={tasks}
+        total={total}
+      />,
+      q('.js-mnt-pending-tasks')
+    );
+  },
+
+  refreshTasks() {
+    // FIXME: don't access state like this. Move state up ASAP.
+    const currentTasksCount = this.taskContainer.state.tasks.length;
+    TaskAPI.get(this.languageCode, { limit: currentTasksCount })
+      .done((data) => {
+        this.setTasks(data.items, data.total);
+      });
   },
 
   refreshStats() {

--- a/pootle/views/api/task.py
+++ b/pootle/views/api/task.py
@@ -14,9 +14,6 @@ from pootle.forms.task import GetTaskForm
 from pootle.models import DueDate
 
 
-PENDING_TASKS_LIMIT = 5
-
-
 class TaskView(View):
     http_method_names = ('get', )
     form_class = GetTaskForm
@@ -47,10 +44,10 @@ class TaskView(View):
         form = kwargs.pop('form')
         lang_code = form.cleaned_data['language'].code
         offset = form.cleaned_data['offset']
-        start = offset
-        end = offset + PENDING_TASKS_LIMIT
+        limit = form.cleaned_data['limit']
 
-        tasks = DueDate.tasks(lang_code, user=self.request.user)[start:end]
+        tasks = DueDate.tasks(lang_code, user=self.request.user)
         return {
-            'items': tasks,
+            'total': tasks.total,
+            'items': tasks[offset:offset + limit],
         }

--- a/tests/data/snapshots/test_get_tasks/admin/context.json
+++ b/tests/data/snapshots/test_get_tasks/admin/context.json
@@ -40,5 +40,6 @@
       "type": "translation",
       "words_left": 166
     }
-  ]
+  ],
+  "total": 6
 }

--- a/tests/data/snapshots/test_get_tasks/member/context.json
+++ b/tests/data/snapshots/test_get_tasks/member/context.json
@@ -40,5 +40,6 @@
       "type": "translation",
       "words_left": 166
     }
-  ]
+  ],
+  "total": 6
 }

--- a/tests/data/snapshots/test_get_tasks_permissions/admin/context.json
+++ b/tests/data/snapshots/test_get_tasks_permissions/admin/context.json
@@ -40,5 +40,6 @@
       "type": "translation",
       "words_left": 166
     }
-  ]
+  ],
+  "total": 6
 }

--- a/tests/data/snapshots/test_get_tasks_permissions/member/context.json
+++ b/tests/data/snapshots/test_get_tasks_permissions/member/context.json
@@ -16,5 +16,6 @@
       "type": "translation",
       "words_left": 166
     }
-  ]
+  ],
+  "total": 2
 }


### PR DESCRIPTION
Whenever due dates are updated from the browsing pages, the list of
tasks visible at the top will be refreshed.

This operation involves the `DueDateContainer` and
`PendingTaskContainer` components, however these currently share no
common ancestor because they are rendered independently. Therefore,
in this commit communication across components happens via the
`PTL.stats` module, however it should be noted that this is a temporal
solution and we should merge the afore-mentioned containers so that
everything is rendered below the same rendering tree.