### PR TITLE
Pending tasks: also provide due date ID to the client

### DIFF
--- a/pootle/core/models/snapshot.py
+++ b/pootle/core/models/snapshot.py
@@ -39,6 +39,7 @@ BLACKLISTED_KEYS = [
     'top_scorers',
     # Taken out until we are able to `reset_sequences` (pytest-django/#308)
     'id',
+    'due_date_id',
 ]
 
 

--- a/pootle/models/duedate.py
+++ b/pootle/models/duedate.py
@@ -97,9 +97,12 @@ class DueDate(models.Model):
     @property
     def project_name(self):
         # FIXME: can we do something which doesn't require the fake user?
-        return Project.objects.cached_dict(
-            FakeUser()
-        )[self.project_code]['fullname']
+        try:
+            return Project.objects.cached_dict(
+                FakeUser()
+            )[self.project_code]['fullname']
+        except KeyError:
+            return self.project_code
 
     @classmethod
     def tasks(cls, language_code, now=None, user=None):
@@ -185,11 +188,8 @@ class DueDate(models.Model):
 
         pending = []
         task_kwargs = {
-            'path': self.pootle_path,
-            'due_on': self.due_on,
+            'due_date': self,
             'now': now,
-            'project_code': self.project_code,
-            'project_name': self.project_name,
         }
 
         critical_count = self.stats.critical

--- a/pootle/models/task.py
+++ b/pootle/models/task.py
@@ -22,21 +22,20 @@ class TranslationTask(object):
     type = 'translation'
     weight = 1
 
-    def __init__(self, path, due_on, now, words_left, project_code,
-                 project_name, **kwargs):
-        self.path = path
-        self.due_on = due_on
+    def __init__(self, due_date, now, words_left, **kwargs):
+        self.due_date = due_date
         self.now = now
         self.words_left = words_left
-        self.project_code = project_code
-        self.project_name = project_name
 
     def __repr__(self):
-        return '<%s: %s (%s)>' % (self.__class__.__name__, self.path, self.due_on)
+        return '<%s: %s (%s)>' % (
+            self.__class__.__name__, self.due_date.pootle_path,
+            self.due_date.due_on,
+        )
 
     @property
     def days_left(self):
-        return days_left(self.now, self.due_on)
+        return days_left(self.now, self.due_date.due_on)
 
     @property
     def importance_factor(self):
@@ -50,11 +49,12 @@ class TranslationTask(object):
     def data(self):
         return {
             'type': self.type,
-            'path': self.path,
-            'due_on': self.due_on,
             'words_left': self.words_left,
-            'project_name': self.project_name,
             'importance_factor': self.importance_factor,
+            'due_date_id': self.due_date.id,
+            'path': self.due_date.pootle_path,
+            'due_on': self.due_date.due_on,
+            'project_name': self.due_date.project_name,
         }
 
 
@@ -87,6 +87,7 @@ class TaskResultSet(object):
     def order_by_importance(self):
         self.tasks = sorted(
             self.tasks,
-            key=lambda x: (-x.importance_factor, x.days_left, x.path),
+            key=lambda x: (-x.importance_factor, x.days_left,
+                           x.due_date.pootle_path),
         )
         return self

--- a/pootle/static/js/browser/components/TaskItem.js
+++ b/pootle/static/js/browser/components/TaskItem.js
@@ -30,7 +30,9 @@ function formatDueTime(msEpoch) {
 }
 
 
-const TaskItem = ({ path, projectName, wordsLeft, dueOnMsEpoch, type }) => {
+const TaskItem = ({
+  path, projectName, wordsLeft, dueDateId, dueOnMsEpoch, type,
+}) => {
   let label;
   let actionUrl = getTranslateUrl(path);
 
@@ -46,7 +48,7 @@ const TaskItem = ({ path, projectName, wordsLeft, dueOnMsEpoch, type }) => {
   const dueDateTooltip = dateTimeTzFormatter.format(dueOnMsEpoch);
 
   const taskComp = (
-    <span className={`task-action task-${type}`}>
+    <span className={`task-action task-${type} task-${dueDateId}`}>
       <span>{label}</span>
       <span className="counter">{wordsLeft}</span>
     </span>
@@ -80,6 +82,7 @@ const TaskItem = ({ path, projectName, wordsLeft, dueOnMsEpoch, type }) => {
   );
 };
 TaskItem.propTypes = {
+  dueDateId: React.PropTypes.number.isRequired,
   dueOnMsEpoch: React.PropTypes.number.isRequired,
   path: React.PropTypes.string.isRequired,
   projectName: React.PropTypes.string.isRequired,

--- a/pootle/static/js/browser/components/TaskList.js
+++ b/pootle/static/js/browser/components/TaskList.js
@@ -33,6 +33,7 @@ const TaskList = ({ tasks }) => (
         importanceFactor={task.importance_factor}
       >
         <TaskItem
+          dueDateId={task.due_date_id}
           dueOnMsEpoch={task.due_on * 1000}
           path={task.path}
           projectName={task.project_name}

--- a/pytest_pootle/factories.py
+++ b/pytest_pootle/factories.py
@@ -225,6 +225,7 @@ class SuggestionFactory(factory.django.DjangoModelFactory):
 class DueDateFactory(factory.django.DjangoModelFactory):
     due_on = timezone.now()
     modified_by = factory.SubFactory(UserFactory)
+    pootle_path = '/foo/'
 
     class Meta(object):
         model = 'pootle.DueDate'

--- a/tests/models/task.py
+++ b/tests/models/task.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 
 import pytest
 
+from pytest_pootle.factories import DueDateFactory
 from pytest_pootle.utils import as_dir
 
 from pootle.core.utils.timezone import aware_datetime
@@ -19,13 +20,11 @@ from pootle.models.task import CriticalTask, TaskResultSet, TranslationTask
 def test_translation_task_repr():
     """Tests `TranslationTask`'s representation."""
     due_on = now = aware_datetime(2017, 02, 28, 9, 00)
+    due_date = DueDateFactory.build(due_on=due_on)
     task = TranslationTask(
-        path='/foo/',
-        due_on=due_on,
+        due_date=due_date,
         now=now,
         words_left=1,
-        project_code='foo',
-        project_name='foo',
     )
     assert (
         task.__repr__() == '<TranslationTask: /foo/ (2017-02-28 09:00:00+01:00)>'
@@ -48,13 +47,11 @@ def test_translation_task_importance_factor(words_left, days_left,
     """Tests `TranslationTask`'s importance factor."""
     now = aware_datetime(2017, 02, 28, 9, 00)
     due_on = now + timedelta(days=days_left)
+    due_date = DueDateFactory.build(due_on=due_on)
     task = TranslationTask(
-        path='/foo/',
-        due_on=due_on,
+        due_date=due_date,
         now=now,
         words_left=words_left,
-        project_code='foo',
-        project_name='foo',
     )
     assert task.importance_factor == expected_factor
 
@@ -69,27 +66,24 @@ def test_critical_task_importance_factor(words_left, days_left,
     """Tests `CriticalTask`'s importance factor."""
     now = aware_datetime(2017, 02, 28, 9, 00)
     due_on = now + timedelta(days=days_left)
+    due_date = DueDateFactory.build(due_on=due_on)
     task = CriticalTask(
-        path='/foo/',
-        due_on=due_on,
+        due_date=due_date,
         now=now,
         words_left=words_left,
-        project_code='foo',
-        project_name='foo',
     )
     assert task.importance_factor == expected_factor
 
 
+@pytest.mark.django_db
 def test_taskresultset_get_single():
     """Tests retrieving a single task resultset item by index."""
     due_on = now = aware_datetime(2017, 02, 28, 9, 00)
+    due_date = DueDateFactory.build(due_on=due_on)
     task = TranslationTask(
-        path='/foo/',
-        due_on=due_on,
+        due_date=due_date,
         now=now,
         words_left=1,
-        project_code='foo',
-        project_name='foo',
     )
     task_resultset = TaskResultSet([task])
     assert task_resultset[0] == task.data
@@ -99,13 +93,11 @@ def test_taskresultset_get_single():
 def test_taskresultset_get_raises(index):
     """Tests retrieving from a task resultset by using an invalid index/slice."""
     due_on = now = aware_datetime(2017, 02, 28, 9, 00)
+    due_date = DueDateFactory.build(due_on=due_on)
     task = TranslationTask(
-        path='/foo/',
-        due_on=due_on,
+        due_date=due_date,
         now=now,
         words_left=1,
-        project_code='foo',
-        project_name='foo',
     )
     task_resultset = TaskResultSet([task])
     with pytest.raises(TypeError):
@@ -116,12 +108,12 @@ class LightTask(object):
     def __init__(self, importance_factor, days_left, path, *args, **kwargs):
         self.importance_factor = importance_factor
         self.days_left = days_left
-        self.path = path
+        self.due_date = DueDateFactory.build(pootle_path=path)
 
     @property
     def data(self):
         return {
-            'path': self.path,
+            'path': self.due_date.pootle_path,
             'days_left': self.days_left,
             'importance_factor': self.importance_factor,
         }


### PR DESCRIPTION
This is necessary so that due dates can be directly modified from the
list of tasks.