### PR TITLE
DueDatePicker: fix display of timezones

### DIFF
--- a/pootle/apps/pootle_misc/context_processors.py
+++ b/pootle/apps/pootle_misc/context_processors.py
@@ -8,12 +8,17 @@
 # AUTHORS file for copyright and authorship information.
 
 from django.conf import settings
-from django.utils import translation
+from django.utils import timezone, translation
 
 from pootle.core.markup import get_markup_filter_name
 from pootle_language.models import Language
 from pootle_project.models import Project
 from staticpages.models import LegalPage
+
+
+local_now = timezone.localtime(timezone.now())
+TZ_OFFSET = local_now.utcoffset().total_seconds()
+TZ_OFFSET_DISPLAY = local_now.strftime('%z')
 
 
 def _agreement_context(request):
@@ -50,7 +55,8 @@ def pootle_context(request):
             'POOTLE_MARKUP_FILTER': get_markup_filter_name(),
             'POOTLE_SIGNUP_ENABLED': settings.POOTLE_SIGNUP_ENABLED,
             'POOTLE_CACHE_TIMEOUT': settings.POOTLE_CACHE_TIMEOUT,
-            'TIME_ZONE': settings.TIME_ZONE,
+            'TZ_OFFSET': TZ_OFFSET,
+            'TZ_OFFSET_DISPLAY': TZ_OFFSET_DISPLAY,
             'DEBUG': settings.DEBUG,
         },
         'custom': settings.POOTLE_CUSTOM_TEMPLATE_CONTEXT,

--- a/pootle/static/js/admin/duedates/components/DueDatePicker.js
+++ b/pootle/static/js/admin/duedates/components/DueDatePicker.js
@@ -10,6 +10,7 @@ import React from 'react';
 import DayPicker, { DateUtils } from 'react-day-picker';
 
 import { t, tct, dateTimeTzFormatter } from 'utils/i18n';
+import { toServerDate, setServerHours } from 'utils/time';
 
 import { formatDueTime } from '../utils';
 
@@ -66,14 +67,10 @@ class DueDatePicker extends React.Component {
     const { selectedDay } = this.state;
 
     if (!selectedDay) {
-      // XXX: hackish but works for now
-      const timezone = (new Intl.DateTimeFormat(PTL.settings.UI_LOCALE, {
-        timeZone: PTL.settings.TIME_ZONE,
-        timeZoneName: 'long',
-      })).format(1).split(' ').slice(1).join(' ');
+      const timezone = `UTC${PTL.settings.TZ_OFFSET_DISPLAY}`;
       const hintMsg = tct(
         'Use the calendar below to select a date by 9:00AM of which ' +
-        ' (in %(timezone)s) this section should be completed.',
+        ' (in %(timezone)s timezone) this section should be completed.',
         { timezone }
       );
 
@@ -82,12 +79,12 @@ class DueDatePicker extends React.Component {
       );
     }
 
-    // FIXME: this needs TZ info! otherwise times will be incorrect/in local TZ
-    const selectedDayMs = this.state.selectedDay.getTime();
+    const serverDate = toServerDate(selectedDay);
+    const serverDateStartOfDay = setServerHours(serverDate, 9, 0);
     return (
       <div>
-        <p>{dateTimeTzFormatter.format(selectedDayMs)}</p>
-        <p>{formatDueTime(selectedDayMs)}</p>
+        <p>{dateTimeTzFormatter.format(serverDateStartOfDay)}</p>
+        <p>{formatDueTime(serverDateStartOfDay)}</p>
       </div>
     );
   }

--- a/pootle/static/js/shared/utils/time.js
+++ b/pootle/static/js/shared/utils/time.js
@@ -135,3 +135,47 @@ export function formatTimeDelta(
 
   return formatted;
 }
+
+
+/**
+ * Converts a `Date` object `localDate` into the server's timezone.
+ *
+ * @param Date localDate a Date object, represented in the local timezone.
+ * @param Integer serverUtcOffset server's offset with respect to UTC,
+ *   in seconds.
+ * @return Date `localDate` localized to server's timezone.
+ */
+export function toServerDate(localDate, {
+    serverUtcOffset = PTL.settings.TZ_OFFSET,
+  } = {}
+) {
+  const localUtcOffsetMs = localDate.getTimezoneOffset() * 60 * 1000;
+  const utcMs = localDate.getTime() - localUtcOffsetMs;
+  const serverUtcOffsetMs = serverUtcOffset * 1000;
+  return new Date(utcMs + serverUtcOffsetMs);
+}
+
+
+/**
+ * Sets a `Date` object's hours according to the server's timezone.
+ *
+ * @param Date date a Date object, represented in the server's timezone.
+ * @param Integer serverUtcOffset server's offset with respect to UTC,
+ *   in seconds.
+ * @return Date a given date's copy adjusted to `hours` in server's timezone.
+ */
+export function setServerHours(serverDate, hours, minutes = null, {
+    serverUtcOffset = PTL.settings.TZ_OFFSET,
+  } = {}
+) {
+  const newDate = new Date(serverDate.getTime());
+  const hoursOffset = serverUtcOffset / (60 * 60);
+  const newUTCHours = (hours - hoursOffset);
+  newDate.setUTCHours(newUTCHours);
+
+  if (minutes) {
+    newDate.setUTCMinutes(minutes);
+  }
+
+  return newDate;
+}

--- a/pootle/templates/layout.html
+++ b/pootle/templates/layout.html
@@ -29,7 +29,8 @@
       MARKUP_FILTER: '{{ settings.POOTLE_MARKUP_FILTER }}',
       SOCIAL_AUTH_PROVIDERS: {{ SOCIAL_AUTH_PROVIDERS|to_js }},
       UI_LOCALE: '{{ LANGUAGE_CODE }}',
-      TIME_ZONE: '{{ settings.TIME_ZONE }}',
+      TZ_OFFSET: {{ settings.TZ_OFFSET }},
+      TZ_OFFSET_DISPLAY: '{{ settings.TZ_OFFSET_DISPLAY }}',
     };
     </script>
 


### PR DESCRIPTION
Whenever a day is selected via react-day-picker, the `day` object
provided by the library is set to `12:00:00` in the client's local time.
In order to dynamically display the proper server time the selected day
represents, the client-side date needs to be:

  * Adjusted to the server's timezone
  * Set to 9:00 in the server's timezone

This requires knowledge of the UTC offset in the client, as well as some
timezone arithmetic which is now done via a couple utility functions.

Implementation note: this hasn't been implemented as a specialized
subclass of `Date` (e.g. `ServerDate`) because subclassing of native
types is limited to pure ES6 environments, and hence transpiling
wouldn't allow us to get there.
Refs. https://babeljs.io/docs/usage/caveats/#classes