### PR TITLE
Due dates: close dropdown upon submission

### DIFF
--- a/pootle/static/js/admin/duedates/components/DueDateContainer.js
+++ b/pootle/static/js/admin/duedates/components/DueDateContainer.js
@@ -21,6 +21,7 @@ class DueDateContainer extends React.Component {
     const { initialDueDate } = props;
     this.state = {
       id: initialDueDate.id,
+      isOpen: false,
       dueOn: initialDueDate.due_on,
       pootlePath: initialDueDate.pootle_path,
     };
@@ -56,12 +57,20 @@ class DueDateContainer extends React.Component {
     PTL.stats.refreshTasks();
   }
 
+  handleToggle() {
+    this.setState((prevState) => ({
+      isOpen: !prevState.isOpen,
+    }));
+  }
+
   render() {
     return (
       <DueDateWidget
         dueOn={this.state.dueOn}
         id={this.state.id}
+        isOpen={this.state.isOpen}
         onRemove={(id) => this.handleRemove(id)}
+        onToggle={() => this.handleToggle()}
         onUpdate={(isoDate) => this.handleUpdate(isoDate)}
       />
     );

--- a/pootle/static/js/admin/duedates/components/DueDateContainer.js
+++ b/pootle/static/js/admin/duedates/components/DueDateContainer.js
@@ -33,6 +33,7 @@ class DueDateContainer extends React.Component {
       .then(() => this.setState({
         id: null,
         dueOn: 0,
+        isOpen: false,
       }, this.handlePostUpdate));
   }
 
@@ -48,6 +49,7 @@ class DueDateContainer extends React.Component {
       this.setState(() => ({
         id: dueDate.id,
         dueOn: dueDate.due_on,
+        isOpen: false,
       }), this.handlePostUpdate);
     });
   }

--- a/pootle/static/js/admin/duedates/components/DueDateWidget.js
+++ b/pootle/static/js/admin/duedates/components/DueDateWidget.js
@@ -11,12 +11,29 @@ import React from 'react';
 import DueDatePicker from './DueDatePicker';
 
 import Dropdown from 'components/Dropdown';
+import DropdownMenu from 'components/DropdownMenu';
+import DropdownToggle from 'components/DropdownToggle';
 import { t, dateTimeTzFormatter } from 'utils/i18n';
 
 import { formatDueTime } from '../utils';
 
 
-const DueDateWidget = ({ dueOn, id, onRemove, onUpdate }) => {
+const propTypes = {
+  dueOn: React.PropTypes.number,
+  id: React.PropTypes.number,
+  isOpen: React.PropTypes.bool.isRequired,
+  onRemove: React.PropTypes.func.isRequired,
+  onToggle: React.PropTypes.func.isRequired,
+  onUpdate: React.PropTypes.func.isRequired,
+};
+
+const defaultProps = {
+  dueOn: 0,
+  id: 0,
+};
+
+
+const DueDateWidget = ({ dueOn, id, isOpen, onRemove, onToggle, onUpdate }) => {
   let dueOnMsg = t('No due date set');
   let dueOnTooltip = null;
   if (dueOn) {
@@ -24,35 +41,25 @@ const DueDateWidget = ({ dueOn, id, onRemove, onUpdate }) => {
     dueOnTooltip = dateTimeTzFormatter.format(dueOn * 1000);
   }
 
-  const dropdownTrigger = (
-    <a title={dueOnTooltip}>
-      {dueOnMsg}
-      <span className="icon-desc" />
-    </a>
-  );
-
   return (
-    <Dropdown trigger={dropdownTrigger}>
-      <DueDatePicker
-        id={id}
-        dueOn={dueOn}
-        onRemove={onRemove}
-        onUpdate={onUpdate}
-      />
+    <Dropdown isOpen={isOpen} onToggle={onToggle}>
+      <DropdownToggle title={dueOnTooltip}>
+        {dueOnMsg}
+      </DropdownToggle>
+      <DropdownMenu>
+        <DueDatePicker
+          id={id}
+          dueOn={dueOn}
+          onRemove={onRemove}
+          onUpdate={onUpdate}
+        />
+      </DropdownMenu>
     </Dropdown>
   );
 };
 
-DueDateWidget.propTypes = {
-  dueOn: React.PropTypes.number,
-  id: React.PropTypes.number,
-  onRemove: React.PropTypes.func.isRequired,
-  onUpdate: React.PropTypes.func.isRequired,
-};
-DueDateWidget.defaultProps = {
-  dueOn: 0,
-  id: 0,
-};
+DueDateWidget.propTypes = propTypes;
+DueDateWidget.defaultProps = defaultProps;
 
 
 export default DueDateWidget;

--- a/pootle/static/js/shared/components/Dropdown.js
+++ b/pootle/static/js/shared/components/Dropdown.js
@@ -11,14 +11,33 @@ import React from 'react';
 import './Dropdown.css';
 
 
+const propTypes = {
+  children: React.PropTypes.node.isRequired,
+  isOpen: React.PropTypes.bool,
+  onToggle: React.PropTypes.func.isRequired,
+  tag: React.PropTypes.oneOfType([
+    React.PropTypes.func,
+    React.PropTypes.string,
+  ]),
+};
+
+const defaultProps = {
+  isOpen: false,
+  tag: 'div',
+};
+
+const childContextTypes = {
+  onMenuMouseDown: React.PropTypes.func.isRequired,
+  onMenuMouseUp: React.PropTypes.func.isRequired,
+  isOpen: React.PropTypes.bool.isRequired,
+  onToggle: React.PropTypes.func.isRequired,
+};
+
+
 class Dropdown extends React.Component {
 
   constructor(props) {
     super(props);
-
-    this.state = {
-      isOpen: props.isInitiallyOpen,
-    };
 
     this.clickedInside = false;
     this.clickTimeout = null;
@@ -27,12 +46,21 @@ class Dropdown extends React.Component {
     this.handleDocClick = this.handleDocClick.bind(this);
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (!prevState.isOpen && this.state.isOpen) {
+  getChildContext() {
+    return {
+      onMenuMouseDown: this.handleMenuMouseDown.bind(this),
+      onMenuMouseUp: this.handleMenuMouseUp.bind(this),
+      isOpen: this.props.isOpen,
+      onToggle: this.props.onToggle,
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.isOpen && this.props.isOpen) {
       document.addEventListener('keydown', this.handleKeyDown);
       document.addEventListener('click', this.handleDocClick);
     }
-    if (prevState.isOpen && !this.state.isOpen) {
+    if (prevProps.isOpen && !this.props.isOpen) {
       document.removeEventListener('keydown', this.handleKeyDown);
       document.removeEventListener('click', this.handleDocClick);
     }
@@ -49,65 +77,41 @@ class Dropdown extends React.Component {
       return;
     }
 
-    this.setState({
-      isOpen: false,
-    });
+    this.props.onToggle();
   }
 
   handleKeyDown(e) {
     if (e.key === 'Escape') {
-      this.setState({
-        isOpen: false,
-      });
+      this.props.onToggle();
     }
   }
 
-  handleContainerMouseDown() {
+  handleMenuMouseDown() {
     this.clickedInside = true;
   }
 
-  handleContainerMouseUp() {
-    this.clickTimeout = setTimeout(() => (this.clickedInside = false), 0);
-  }
-
-  handleTriggerClick() {
-    this.setState((prevState) => ({
-      isOpen: !prevState.isOpen,
-    }));
+  handleMenuMouseUp() {
+    this.clickTimeout = setTimeout(() => {
+      this.clickedInside = false;
+    }, 0);
   }
 
   render() {
+    const Tag = this.props.tag;
+
     return (
-      <div
+      <Tag
         className="dropdown-wrapper"
       >
-        <div onClick={() => this.handleTriggerClick()} >
-          {this.props.trigger}
-        </div>
-        {this.state.isOpen &&
-          <div
-            className="dropdown-container"
-            onMouseDown={() => this.handleContainerMouseDown()}
-            onMouseUp={() => this.handleContainerMouseUp()}
-            tabIndex="0"
-          >
-          {React.Children.only(this.props.children)}
-          </div>
-        }
-      </div>
+        {this.props.children}
+      </Tag>
     );
   }
 }
 
-Dropdown.propTypes = {
-  isInitiallyOpen: React.PropTypes.bool,
-  trigger: React.PropTypes.node.isRequired,
-  children: React.PropTypes.node.isRequired,
-};
-
-Dropdown.defaultProps = {
-  isInitiallyOpen: false,
-};
+Dropdown.propTypes = propTypes;
+Dropdown.defaultProps = defaultProps;
+Dropdown.childContextTypes = childContextTypes;
 
 
 export default Dropdown;

--- a/pootle/static/js/shared/components/DropdownMenu.js
+++ b/pootle/static/js/shared/components/DropdownMenu.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) Zing contributors.
+ *
+ * This file is a part of the Zing project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import React from 'react';
+
+
+const propTypes = {
+  children: React.PropTypes.node.isRequired,
+};
+
+const contextTypes = {
+  isOpen: React.PropTypes.bool.isRequired,
+  onMenuMouseDown: React.PropTypes.func.isRequired,
+  onMenuMouseUp: React.PropTypes.func.isRequired,
+};
+
+
+const DropdownMenu = ({ children }, context) => {
+  if (!context.isOpen) {
+    // FIXME: use `null` once in React 15+
+    // Refs. https://github.com/facebook/react/issues/5355
+    return <noscript />;
+  }
+
+  return (
+    <div
+      className="dropdown-container"
+      onMouseDown={context.onMenuMouseDown}
+      onMouseUp={context.onMenuMouseUp}
+      role="menu"
+      tabIndex="0"
+    >
+      {children}
+    </div>
+  );
+};
+
+DropdownMenu.propTypes = propTypes;
+DropdownMenu.contextTypes = contextTypes;
+
+
+export default DropdownMenu;

--- a/pootle/static/js/shared/components/DropdownToggle.js
+++ b/pootle/static/js/shared/components/DropdownToggle.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) Zing contributors.
+ *
+ * This file is a part of the Zing project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import React from 'react';
+
+
+const propTypes = {
+  children: React.PropTypes.node.isRequired,
+  tag: React.PropTypes.oneOfType([
+    React.PropTypes.func,
+    React.PropTypes.string,
+  ]),
+  title: React.PropTypes.string,
+};
+
+const defaultProps = {
+  title: '',
+  tag: 'a',
+};
+
+const contextTypes = {
+  onToggle: React.PropTypes.func.isRequired,
+};
+
+
+// XXX: make icon-desc optional via prop?
+const DropdownToggle = ({ children, title, tag: Tag }, context) => {
+  const extraProps = title ? { title } : {};
+
+  return (
+    <Tag
+      onClick={() => context.onToggle()}
+      {...extraProps}
+    >
+      {children}
+      <span className="icon-desc" />
+    </Tag>
+  );
+};
+
+DropdownToggle.propTypes = propTypes;
+DropdownToggle.defaultProps = defaultProps;
+DropdownToggle.contextTypes = contextTypes;
+
+
+export default DropdownToggle;


### PR DESCRIPTION
This PR changes the due date administration widget so that the dropdown is closed upon submission. In order to do that, state had to be lifted up, and the dropdown component has been reworked to be fully controlled and read the open state via props.