### PR TITLE
Always assume assets are under pootle/assets directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ CWD = $(shell pwd)
 SRC_DIR = ${CWD}/pootle
 DOCS_DIR = ${CWD}/docs
 STATIC_DIR = ${SRC_DIR}/static
-ASSETS_DIR = $(shell python -c "from pootle.settings import *; print(STATIC_ROOT)")
+# The ASSETS_DIR is where STATIC_ROOT configuration variable
+# usually points to (see pootle/settings/10-base.conf)
+ASSETS_DIR = ${SRC_DIR}/assets
 JS_DIR = ${STATIC_DIR}/js
 FORMATS=--formats=bztar
 TEST_ENV_NAME = pootle_test_env
@@ -33,12 +35,12 @@ assets:
 	${POOTLE_CMD} collectstatic --noinput --clear -i node_modules -i .tox -i docs ${TAIL}
 	${POOTLE_CMD} assets build ${TAIL}
 
-	chmod 664 ${ASSETS_DIR}.webassets-cache/*
+	chmod 664 ${ASSETS_DIR}/.webassets-cache/*
 
 travis-assets:
 	npm --version
 	node --version
-	if [ -d "${ASSETS_DIR}.webassets-cache/" ]; then \
+	if [ -d "${ASSETS_DIR}/.webassets-cache" ]; then \
 		echo "eating cache - yum!"; \
 	else \
 		cd ${JS_DIR} && \
@@ -49,7 +51,7 @@ travis-assets:
 		mkdir -p ${ASSETS_DIR}; \
 		${POOTLE_CMD} collectstatic --noinput --clear -i node_modules -i .tox -i docs ${TAIL}; \
 		${POOTLE_CMD} assets build ${TAIL}; \
-		chmod 664 ${ASSETS_DIR}.webassets-cache/*; \
+		chmod 664 ${ASSETS_DIR}/.webassets-cache/*; \
 	fi
 
 docs:

--- a/pootle/settings/10-base.conf
+++ b/pootle/settings/10-base.conf
@@ -45,9 +45,12 @@ MEDIA_ROOT = working_path('media') + '/'
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
 MEDIA_URL = '/media/'
 
-# The absolute path to the directory where collectstatic
-# will collect static files for deployment.
-# Example: "/var/www/example.com/static/"
+# The absolute path to the directory where generated static
+# assets will be stored. `make assets` is hardcoded to use
+# `<zing_root>/assets/`, so there's no need to override this value
+# on production. In development mode, one might want to set this to
+# `working_path('static') + '/'` together with `ASSETS_DEBUG = True`
+# and skip the `make assets` step altogether
 STATIC_ROOT = working_path('assets') + '/'
 
 # URL to use when referring to static files located in


### PR DESCRIPTION
This makes Makefile compatible with proxy `zing` script
that deals with virtualenv internally.

Also, don't make the trailing slash a part of ASSETS_DIR
for consistency with other variables. Use separator slash
explicitly in the paths that use ASSETS_DIR.

@julen please review/merge