### PR TITLE
Cleanup: make it easier to understand some fixtures/tests

### DIFF
--- a/pytest_pootle/fixtures/models/store.py
+++ b/pytest_pootle/fixtures/models/store.py
@@ -129,7 +129,12 @@ def _setup_store_test(store, member, member2, test):
         revisions = [unit.revision for unit in units_before]
         store_revision = sum(revisions) / len(revisions)
 
-    return (store, units_update, store_revision, units_before, member, member2)
+    return {
+        'store': store,
+        'units_update': units_update,
+        'store_revision': store_revision,
+        'units_before_update': units_before,
+    }
 
 
 @pytest.fixture(params=UPDATE_STORE_TESTS.keys())
@@ -143,24 +148,27 @@ def store_diff_tests(request, tp0, member, member2):
 
     test = _setup_store_test(store, member, member2,
                              UPDATE_STORE_TESTS[request.param])
-    test_store = create_store(units=test[1])
-    return [StoreDiff(test[0], test_store, test[2])] + list(test[:3])
+    test_store = create_store(units=test['units_update'])
+
+    return {
+        'diff': StoreDiff(test['store'], test_store, test['store_revision']),
+        'store': test['store'],
+        'units_update': test['units_update'],
+        'store_revision': test['store_revision'],
+    }
 
 
 @pytest.fixture(params=UPDATE_STORE_TESTS.keys())
 def param_update_store_test(request, tp0, member, member2):
     from pytest_pootle.factories import StoreDBFactory
 
-    store = StoreDBFactory(
-        translation_project=tp0,
-        parent=tp0.directory)
-    test = _setup_store_test(
-        store, member, member2,
-        UPDATE_STORE_TESTS[request.param])
+    store = StoreDBFactory(translation_project=tp0, parent=tp0.directory)
+    test = _setup_store_test(store, member, member2,
+                             UPDATE_STORE_TESTS[request.param])
     update_store(
-        test[0],
-        units=test[1],
-        store_revision=test[2],
+        test['store'],
+        units=test['units_update'],
+        store_revision=test['store_revision'],
         user=member2,
     )
     return test

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -215,17 +215,15 @@ def test_update_set_last_sync_revision(project0_disk, tp0, store0, test_fs):
     assert dbunit.revision == store0.last_sync_revision + 1
 
 
-def _test_store_update_indexes(store, *test_args):
+def _test_store_update_indexes(store):
     # make sure indexes are not fooed indexes only have to be unique
     indexes = [x.index for x in store.units]
     assert len(indexes) == len(set(indexes))
 
 
-def _test_store_update_units_before(*test_args):
+def _test_store_update_units_before(store, units_update, store_revision,
+                                    units_before, member2):
     # test what has happened to the units that were present before the update
-    (store, units_update, store_revision,
-     units_before, member_, member2) = test_args
-
     updates = {unit[0]: unit[1] for unit in units_update}
 
     for unit in units_before:
@@ -281,10 +279,8 @@ def _test_store_update_units_before(*test_args):
         assert suggestion.user == member2
 
 
-def _test_store_update_ordering(*test_args):
-    (store, units_update, store_revision,
-     units_before, member_, member2_) = test_args
-
+def _test_store_update_ordering(store, units_update, store_revision,
+                                units_before):
     updates = {unit[0]: unit[1] for unit in units_update}
     old_units = {unit.source: unit for unit in units_before}
 
@@ -308,10 +304,8 @@ def _test_store_update_ordering(*test_args):
     assert new_unit_list == [x.source for x in store.units]
 
 
-def _test_store_update_units_now(*test_args):
-    (store, units_update, store_revision,
-     units_before, member_, member2_) = test_args
-
+def _test_store_update_units_now(store, units_update, store_revision,
+                                 units_before):
     # test that all the current units should be there
     updates = {unit[0]: unit[1] for unit in units_update}
     old_units = {unit.source: unit for unit in units_before}
@@ -323,16 +317,30 @@ def _test_store_update_units_now(*test_args):
 
 
 @pytest.mark.django_db
-def test_store_update(param_update_store_test):
-    _test_store_update_indexes(*param_update_store_test)
-    _test_store_update_units_before(*param_update_store_test)
-    _test_store_update_units_now(*param_update_store_test)
-    _test_store_update_ordering(*param_update_store_test)
+def test_store_update(param_update_store_test, member2):
+    store = param_update_store_test['store']
+    units_update = param_update_store_test['units_update']
+    store_revision = param_update_store_test['store_revision']
+    units_before_update = param_update_store_test['units_before_update']
+
+    _test_store_update_indexes(store)
+
+    _test_store_update_units_before(store, units_update, store_revision,
+                                    units_before_update, member2)
+
+    _test_store_update_units_now(store, units_update, store_revision,
+                                 units_before_update)
+
+    _test_store_update_ordering(store, units_update, store_revision,
+                                units_before_update)
 
 
 @pytest.mark.django_db
 def test_store_file_diff(store_diff_tests):
-    diff, store, update_units, store_revision = store_diff_tests
+    diff = store_diff_tests['diff']
+    store = store_diff_tests['store']
+    update_units = store_diff_tests['units_update']
+    store_revision = store_diff_tests['store_revision']
 
     assert diff.target_store == store
     assert diff.source_revision == store_revision


### PR DESCRIPTION
The explicitness of keyword arguments helps more than the implicitness
of positional arguments. This is especially true when dealing with many
arguments at a time.