### PR TITLE
Cleanup: remove dead code from update/sync commands

### DIFF
--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -90,16 +91,6 @@ class PootleCommand(BaseCommand):
                 logging.exception(u"Failed to run %s over %s's files",
                                   self.name, tp)
                 return
-        elif hasattr(self, "handle_store"):
-            store_query = tp.stores.live()
-            for store in store_query.iterator():
-                logging.info(u"Running %s over %s",
-                             self.name, store.pootle_path)
-                try:
-                    self.handle_store(store, **options)
-                except Exception:
-                    logging.exception(u"Failed to run %s over %s",
-                                      self.name, store.pootle_path)
 
     def handle(self, **options):
         # adjust debug level to the verbosity option

--- a/pootle/apps/pootle_app/management/commands/sync_stores.py
+++ b/pootle/apps/pootle_app/management/commands/sync_stores.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -48,11 +49,3 @@ class Command(PootleCommand):
                 skip_missing=options['skip_missing'],
                 only_newer=not options['force']
             )
-
-    def handle_store(self, store, **options):
-        store.sync(
-            conservative=not options['overwrite'],
-            update_structure=options['overwrite'],
-            skip_missing=options['skip_missing'],
-            only_newer=not options['force']
-        )

--- a/pootle/apps/pootle_app/management/commands/update_stores.py
+++ b/pootle/apps/pootle_app/management/commands/update_stores.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
@@ -55,18 +56,6 @@ class Command(PootleCommand):
                             translation_project.project, translation_project)
 
         return False
-
-    def handle_store(self, store, **options):
-        if not store.file:
-            return
-        disk_mtime = store.get_file_mtime()
-        if not options["force"] and disk_mtime == store.file_mtime:
-            # The file on disk wasn't changed since the last sync
-            logging.debug(u"File didn't change since last sync, "
-                          "skipping %s", store.pootle_path)
-            return
-
-        store.update_from_disk(overwrite=options["overwrite"])
 
     def handle_all(self, **options):
         scan_translation_projects(languages=self.languages,


### PR DESCRIPTION
The `handle_store` hook is unused and never called:

  * for `sync_stores`, the `handle_all_stores` takes over
  * for `update_stores`, the `handle_translation_project` method always
    returns a falsy value, and no store-specific methods will be executed.