### PR TITLE
Cleanup on diffable classes

### DIFF
--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -89,6 +89,10 @@ class FileStore(object):
             'translator_comment': unit.getnotes(origin='translator'),
         }
 
+    def get_unit(self, id):
+        """Retrieves a comparable `FileUnit` object by `id`."""
+        return FileUnit(self.units[id])
+
 
 class DBStore(object):
     """DB store representation for diffing."""
@@ -109,6 +113,10 @@ class DBStore(object):
         return OrderedDict(
             (unit['unitid'], unit) for unit in units
         )
+
+    def get_unit(self, id):
+        """Retrieves a comparable `DBUnit` object by `id`."""
+        return DBUnit(self.units[id])
 
 
 class StoreDiff(object):
@@ -291,8 +299,7 @@ class StoreDiff(object):
                 for uid in self.active_target_units[i1:i2]
                 if (
                     uid in self.source.units
-                    and FileUnit(self.source.units[uid])
-                    != DBUnit(self.target.units[uid])
+                    and self.source.get_unit(uid) != self.target.get_unit(uid)
                 )
             ))
 

--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -170,6 +170,7 @@ class StoreDiff(object):
     @cached_property
     def insert_points(self):
         """Returns a list of insert points with update index info.
+
         :return: a list of tuples
             `(insert_at, uids_to_add, next_index, update_index_delta)` where
                 * `insert_at` is the point for inserting,
@@ -180,35 +181,37 @@ class StoreDiff(object):
         """
         inserts = []
         new_unitid_list = self.new_unit_list
+        units = self.target.units
+        active_uids = self.target.active_uids
+
         for (tag, i1, i2, j1, j2) in self.opcodes:
             if tag == 'insert':
                 update_index_delta = 0
                 insert_at = 0
                 if i1 > 0:
-                    insert_at = (
-                        self.target.units[
-                            self.target.active_uids[i1 - 1]]['index'])
-                next_index = insert_at + 1
-                if i1 < len(self.target.active_uids):
-                    next_index = self.target.units[
-                        self.target.active_uids[i1]]["index"]
-                    update_index_delta = (
-                        j2 - j1 - next_index + insert_at + 1)
+                    insert_at = units[active_uids[i1 - 1]]['index']
 
-                inserts.append((insert_at,
-                                new_unitid_list[j1:j2],
-                                next_index,
-                                update_index_delta))
+                next_index = insert_at + 1
+                if i1 < len(active_uids):
+                    next_index = units[active_uids[i1]]['index']
+                    update_index_delta = j2 - j1 - next_index + insert_at + 1
+
+                inserts.append((
+                    insert_at,
+                    new_unitid_list[j1:j2],
+                    next_index,
+                    update_index_delta,
+                ))
 
             elif tag == 'replace':
-                insert_at = self.target.units[
-                    self.target.active_uids[i1 - 1]]['index']
-                next_index = self.target.units[
-                    self.target.active_uids[i2 - 1]]['index']
-                inserts.append((insert_at,
-                                new_unitid_list[j1:j2],
-                                next_index,
-                                j2 - j1 - insert_at + next_index))
+                insert_at = units[active_uids[i1 - 1]]['index']
+                next_index = units[active_uids[i2 - 1]]['index']
+                inserts.append((
+                    insert_at,
+                    new_unitid_list[j1:j2],
+                    next_index,
+                    j2 - j1 - insert_at + next_index,
+                ))
 
         return inserts
 

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -335,11 +335,11 @@ def test_store_file_diff(store_diff_tests):
     assert (
         units_in_file
         == [(x.source, x.target) for x in diff.source_store.units[1:]]
-        == [(v['source'], v['target']) for v in diff.source_units.values()])
+        == [(v['source'], v['target']) for v in diff.source.units.values()])
     assert diff.active_target_units == [x.source for x in store.units]
     assert diff.target_revision == store.get_max_unit_revision()
     assert (
-        diff.target_units
+        diff.target.units
         == {unit["source_f"]: unit
             for unit
             in store.unit_set.values("source_f", "index", "target_f",

--- a/tests/models/store.py
+++ b/tests/models/store.py
@@ -336,7 +336,7 @@ def test_store_file_diff(store_diff_tests):
         units_in_file
         == [(x.source, x.target) for x in diff.source_store.units[1:]]
         == [(v['source'], v['target']) for v in diff.source.units.values()])
-    assert diff.active_target_units == [x.source for x in store.units]
+    assert diff.target.active_uids == [x.source for x in store.units]
     assert diff.target_revision == store.get_max_unit_revision()
     assert (
         diff.target.units


### PR DESCRIPTION
This PR splits the `DiffableStore` into `FileStore` and `DBStore` classes and moves the querying logic that belongs to specific classes away from `DiffableStore`. With docstring additions and other minor cleanups, it should now be easier to follow along the code path.