### PR TITLE
Cleanup: remove unused PO headers

### DIFF
--- a/pootle/apps/pootle_store/syncer.py
+++ b/pootle/apps/pootle_store/syncer.py
@@ -20,7 +20,6 @@ from django.utils.functional import cached_property
 from pootle.core.log import log
 from pootle.core.mixins import CachedMethods
 from pootle.core.url_helpers import split_pootle_path
-from pootle.core.utils import dateformat
 from pootle.core.utils.timezone import datetime_min
 from pootle.core.utils.version import get_major_minor_version
 from pootle_statistics.models import Submission
@@ -402,14 +401,10 @@ class PoStoreSyncer(StoreSyncer):
     def get_po_revision_date(self, mtime):
         return '%s%s' % (mtime.strftime('%Y-%m-%d %H:%M'), poheader.tzstring())
 
-    def get_po_mtime(self, mtime):
-        return '%s.%06d' % (int(dateformat.format(mtime, 'U')), mtime.microsecond)
-
     def get_po_headers(self, mtime, user_displayname, user_email):
         headerupdates = {
             'PO_Revision_Date': self.get_po_revision_date(mtime),
             'X_Generator': "Zing %s" % get_major_minor_version(),
-            'X_POOTLE_MTIME': self.get_po_mtime(mtime),
         }
         headerupdates['Last_Translator'] = (
             user_displayname and user_email

--- a/pytest_pootle/utils.py
+++ b/pytest_pootle/utils.py
@@ -26,13 +26,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\\n"
 "Content-Transfer-Encoding: 8bit\\n"
 "X-Generator: Pootle Tests\\n"
-%(x_pootle_headers)s
 
 %(units)s
-"""
-
-STRING_POOTLE_HEADERS = """
-"X-Pootle-Path: %(pootle_path)s\\n"
 """
 
 STRING_UNIT = """
@@ -58,18 +53,12 @@ def setup_store(pootle_path):
         translation_project=tp, parent=directory, name=filename)
 
 
-def create_store(pootle_path=None, units=None):
+def create_store(units=None):
     _units = []
     for src, target in units or []:
         _units.append(STRING_UNIT % {"src": src, "target": target})
     units = "\n\n".join(_units)
-    x_pootle_headers = ""
-    if pootle_path:
-        x_pootle_headers = (STRING_POOTLE_HEADERS.strip() % {
-            'pootle_path': pootle_path,
-        })
-    string_store = STRING_STORE % {"x_pootle_headers": x_pootle_headers,
-                                   "units": units}
+    string_store = STRING_STORE % {'units': units}
     io_store = io.BytesIO(string_store.encode('utf-8'))
     return getclass(io_store)(io_store.read())
 

--- a/tests/models/submission.py
+++ b/tests/models/submission.py
@@ -135,7 +135,6 @@ def test_update_submission_ordering():
     unit.save()
 
     store = create_store(
-        unit.store.pootle_path,
         [(unit.source_f, "Translation for " + unit.source_f)]
     )
     unit.store.update(store)


### PR DESCRIPTION
These were used in the past for upload file merging and import/export.