### PR TITLE
Bugfix: resurrect updated obsolete units (2nd approach)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Zing Changelog
 v0.3.2 (in development)
 -----------------------
 
+* Fixed a synchronization bug where obsolete but unsynced units could not be
+  resurrected (#246).
+
 
 v0.3.1 (2017-02-15)
 -------------------

--- a/pootle/apps/pootle_store/diff.py
+++ b/pootle/apps/pootle_store/diff.py
@@ -135,16 +135,6 @@ class DBStore(object):
         """Retrieves a comparable `DBUnit` object by `id`."""
         return DBUnit(self.units[id])
 
-    def get_obsoleted_uids(self, since_revision):
-        """Return a list of unit IDs that were obsoleted since
-        `since_revision` revision.
-        """
-        return [
-            uid for uid, unit in self.units.items()
-            if (unit['state'] == OBSOLETE
-                and unit['revision'] > since_revision)
-        ]
-
     def get_updated_uids(self, since_revision):
         """Return a list of *active* unit IDs that were updated since
         `since_revision` revision.
@@ -239,16 +229,11 @@ class StoreDiff(object):
         new_units = [u for u in self.updated_target_units
                      if u not in self.source.units]
 
-        # These unit are either present in both or only in the file so are
+        # These units are either present in both or only in the file so are
         # kept in the file order
-        new_units += [u for u in self.source.units.keys()
-                      if u not in self.obsoleted_target_units]
+        new_units += self.source.units.keys()
 
         return new_units
-
-    @cached_property
-    def obsoleted_target_units(self):
-        return self.target.get_obsoleted_uids(since_revision=self.source_revision)
 
     @cached_property
     def updated_target_units(self):

--- a/pootle/apps/pootle_store/models.py
+++ b/pootle/apps/pootle_store/models.py
@@ -872,9 +872,10 @@ class Unit(models.Model, base.TranslationUnit):
         """Bring a unit's state back to life.
 
         :param is_fuzzy: whether the unit is in fuzzy state or not.
+        :return: `True` if the unit was resurrected, `False` otherwise.
         """
         if self.state > OBSOLETE:
-            return
+            return False
 
         if filter(None, self.target_f.strings):
             # when Unit toggles its OBSOLETE state the number of translated
@@ -890,6 +891,7 @@ class Unit(models.Model, base.TranslationUnit):
         self.update_qualitychecks(keep_false_positives=True)
         self._state_updated = True
         self._save_action = UNIT_RESURRECTED
+        return True
 
     def istranslated(self):
         if self._target_updated and not self.isfuzzy():

--- a/tests/models/unit.py
+++ b/tests/models/unit.py
@@ -395,3 +395,12 @@ def test_unit_syncer_locations(unit_syncer):
     newunit = syncer.convert(unit_class)
     assert newunit.getlocations() == ["FOO"]
     _test_unit_syncer(unit, newunit)
+
+
+@pytest.mark.django_db
+def test_unit_resurrect_active_unit(store0):
+    """Tests unit resurrection does nothing for active units."""
+    unit = store0.units.first()
+    assert not unit.isobsolete()
+    assert not unit.resurrect()
+    assert not unit.isobsolete()


### PR DESCRIPTION
This PR implements the 2nd approach described in https://github.com/evernote/zing/issues/246#issuecomment-290708709 in order to ensure obsolete units that were changed since the last sync don't stay in limbo when they should be resurrected.

Fixes #246.