### PR TITLE
Browser: fix visiting fully untranslated stores

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Zing Changelog
 v0.4.1 (in development)
 -----------------------
 
+* Fixed browsing pages for fully untranslated stores.
+
 
 v0.4.0 (2017-04-06)
 -------------------

--- a/pootle/static/js/browser/components/DetailedStats.js
+++ b/pootle/static/js/browser/components/DetailedStats.js
@@ -68,7 +68,7 @@ const DetailedStats = ({
           </div>
         </div>
       }
-      {lastAction.mtime !== 0 &&
+      {lastAction && lastAction.mtime !== 0 &&
         <div>
           <h3 className="top">{t('Translations')}</h3>
           <div className="bd">

--- a/pootle/static/js/browser/components/TranslationState.js
+++ b/pootle/static/js/browser/components/TranslationState.js
@@ -32,13 +32,14 @@ const TranslationState = ({
 );
 TranslationState.propTypes = {
   total: React.PropTypes.number.isRequired,
-  translated: React.PropTypes.number.isRequired,
+  translated: React.PropTypes.number,
   fuzzy: React.PropTypes.number,
   canTranslate: React.PropTypes.bool.isRequired,
   pootlePath: React.PropTypes.string.isRequired,
 };
 TranslationState.defaultProps = {
   fuzzy: 0,
+  translated: 0,
 };
 
 export default TranslationState;


### PR DESCRIPTION
When zero, the backend strips the amount of translated words, hence we
need to provide a default value.

We now also safeguard for missing last action data.