### PR TITLE
Tasks: ensure loading more retrieves fresh items

### DIFF
--- a/pootle/forms/task.py
+++ b/pootle/forms/task.py
@@ -21,11 +21,7 @@ class GetTaskForm(forms.Form):
         queryset=Language.live.all(),
         to_field_name='code',
     )
-    offset = forms.IntegerField(required=False)
     limit = forms.IntegerField(required=False)
-
-    def clean_offset(self):
-        return self.cleaned_data.get('offset') or 0
 
     def clean_limit(self):
         limit = self.cleaned_data.get('limit') or PENDING_TASKS_LIMIT

--- a/pootle/static/js/browser/components/PendingTaskContainer.js
+++ b/pootle/static/js/browser/components/PendingTaskContainer.js
@@ -48,9 +48,9 @@ class PendingTaskContainer extends React.Component {
     clearInterval(this.intervalId);
   }
 
-  handleRefresh() {
-    const currentTasksCount = this.state.tasks.length;
-    TaskAPI.get(this.props.languageCode, { limit: currentTasksCount })
+  handleRefresh(opts = { extra: 0 }) {
+    const limit = this.state.tasks.length + opts.extra;
+    return TaskAPI.get(this.props.languageCode, { limit })
       .done((data) => {
         this.setState({ tasks: data.items, total: data.total });
       });
@@ -58,17 +58,7 @@ class PendingTaskContainer extends React.Component {
 
   handleLoadMore(e) {
     e.preventDefault();
-
-    const params = { offset: this.state.tasks.length };
-    return TaskAPI.get(this.props.languageCode, params)
-      .done((data) => {
-        this.setState((prevState) => {
-          const newItems = prevState.tasks.concat(data.items);
-          return {
-            tasks: newItems,
-          };
-        });
-      });
+    return this.handleRefresh({ extra: 5 });
   }
 
   renderLoadMore() {

--- a/pootle/static/js/shared/api/TaskAPI.js
+++ b/pootle/static/js/shared/api/TaskAPI.js
@@ -13,13 +13,10 @@ const TaskAPI = {
 
   apiRoot: '/xhr/tasks/',
 
-  get(languageCode, { offset = 0, limit = 0 } = {}) {
+  get(languageCode, { limit = 0 } = {}) {
     let url = `${this.apiRoot}${languageCode}/`;
     const params = {};
 
-    if (offset > 0) {
-      params.offset = offset;
-    }
     if (limit > 0) {
       params.limit = limit;
     }

--- a/pootle/views/api/task.py
+++ b/pootle/views/api/task.py
@@ -43,11 +43,10 @@ class TaskView(View):
     def get_context_data(self, *args, **kwargs):
         form = kwargs.pop('form')
         lang_code = form.cleaned_data['language'].code
-        offset = form.cleaned_data['offset']
         limit = form.cleaned_data['limit']
 
         tasks = DueDate.tasks(lang_code, user=self.request.user)
         return {
             'total': tasks.total,
-            'items': tasks[offset:offset + limit],
+            'items': tasks[:limit],
         }


### PR DESCRIPTION
Retrieving via an offset would be problematic if the list of tasks
changed out of the scope of the current tab, hence providing incorrect
data.

Fixes #256.