### PR TITLE
i18n: avoid timezone breakage in older Android Webkit browsers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Zing Changelog
 v0.5.2 (in development)
 -----------------------
 
+* Worked aaround an issue in older versions of Android+Webkit, where timezones
+  would be reported as abbreviations, and not as IANA compliant names. This
+  broke client scripts.
+
 
 v0.5.1 (2017-05-29)
 -------------------

--- a/pootle/static/js/shared/utils/i18n.js
+++ b/pootle/static/js/shared/utils/i18n.js
@@ -217,8 +217,23 @@ try {
   isTzSupported = !(e instanceof RangeError);
 }
 
+let userTimeZone = (new Intl.DateTimeFormat()).resolvedOptions().timeZone;
+
+// In older Android+Webkit browsers, the timezone might be reported as an
+// abbreviation (e.g. 'CET'), but Intl formatting functions require timezone
+// names as they appear in the IANA DB. In such cases, fall back to the server
+// timezone to avoid breakage.
+if (userTimeZone.indexOf('/') === -1 &&
+    ['UTC', 'GMT'].indexOf(userTimeZone) === -1) {
+  console.log(
+    'Intl.timeZone: got a timezone not compliant with the IANA DB: ',
+    userTimeZone
+  );
+  userTimeZone = PTL.settings.TZ;
+}
+
 const tzOptions = isTzSupported ? {
-  timeZone: (new Intl.DateTimeFormat()).resolvedOptions().timeZone,
+  timeZone: userTimeZone,
   timeZoneName: 'short',
 } : {};
 


### PR DESCRIPTION
In older Android+Webkit browsers, the timezone might be reported as an
abbreviation (e.g. 'CET'), but Intl formatting functions require timezone
names as they appear in the IANA DB.

This broke scripts altogether, so now we detect this scenario and fall
back to the server timezone to work around it.