### PR TITLE
requirements: pin urllib3 to avoid breakage

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,3 +25,6 @@ rq==0.7.1
 
 # Translate Toolkit
 translate-toolkit==2.0.0rc3
+
+# Pin to avoid breakage
+urllib3==1.21.1


### PR DESCRIPTION
In master tests broke because `requests` updated to `urllib3` to 1.22, and some other dependency (not sure which one) requires `urllib3 < 1.22`.