### PR TITLE
Admin dashboard: remove expensive server statistics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Zing Changelog
 v0.5.3 (in development)
 -----------------------
 
+* Removed expensive server stats from the admin dashboard (#260).
+
 
 v0.5.2 (2017-07-21)
 -------------------

--- a/pootle/apps/pootle_app/views/admin/dashboard.py
+++ b/pootle/apps/pootle_app/views/admin/dashboard.py
@@ -1,18 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) Pootle contributors.
+# Copyright (C) Zing contributors.
 #
-# This file is a part of the Pootle project. It is distributed under the GPL3
+# This file is a part of the Zing project. It is distributed under the GPL3
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-import locale
-import os
-
 from redis.exceptions import ConnectionError
 
-from django.contrib.auth import get_user_model
-from django.core.cache import cache
 from django.shortcuts import render
 
 from django_rq.queues import get_failed_queue, get_queue
@@ -20,35 +16,6 @@ from django_rq.workers import Worker
 
 from pootle.core.decorators import admin_required
 from pootle.i18n.gettext import ugettext as _, ungettext
-from pootle_statistics.models import Submission
-from pootle_store.models import Suggestion
-
-
-def _format_numbers(numbers):
-    for k in numbers.keys():
-        formatted_number = locale.format("%d", numbers[k], grouping=True)
-        # Under Windows, formatted number must be converted to Unicode
-        if os.name == 'nt':
-            formatted_number = formatted_number.decode(
-                locale.getpreferredencoding()
-            )
-        numbers[k] = formatted_number
-
-
-def server_stats():
-    User = get_user_model()
-    result = cache.get("server_stats")
-    if result is None:
-        result = {}
-        result['user_count'] = max(User.objects.filter(
-            is_active=True).count()-2, 0)
-        # 'default' and 'nobody' might be counted
-        # FIXME: the special users should not be retuned with is_active
-        result['submission_count'] = Submission.objects.count()
-        result['pending_count'] = Suggestion.objects.pending().count()
-        cache.set("server_stats", result, 86400)
-    _format_numbers(result)
-    return result
 
 
 def rq_stats():
@@ -89,7 +56,6 @@ def checks():
 def view(request):
     ctx = {
         'page': 'admin-dashboard',
-        'server_stats': server_stats(),
         'rq_stats': rq_stats(),
         'checks': checks(),
     }

--- a/pootle/templates/admin/dashboard.html
+++ b/pootle/templates/admin/dashboard.html
@@ -4,28 +4,6 @@
 {% block section_body %}
 <div id="serverstats" class="module first" lang="{{ LANGUAGE_CODE }}">
   <div class="hd">
-    <h2>{% trans "Server Statistics" %}</h2>
-  </div>
-  <div class="bd">
-    <table>
-      <tbody>
-        <tr>
-          <th scope="row">{% trans "Submissions" %}</th>
-          <td class="stats-number">{{ server_stats.submission_count }}</td>
-        </tr>
-        <tr>
-          <th scope="row">{% trans "Pending suggestions" %}</th>
-          <td class="stats-number">{{ server_stats.pending_count }}</td>
-        </tr>
-        <tr>
-          <th scope="row">{% trans "Users" %}</th>
-          <td class="stats-number">{{ server_stats.user_count }}</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-
-  <div class="hd">
     <h2>{% trans "Background Jobs" %}</h2>
   </div>
   <div class="bd">


### PR DESCRIPTION
Even if cached, calculating these numbers adds unnecessary extra load on
the server, as the numbers provided there are of no regular use.