### PR TITLE
SocialVerificationView: ensure the right form is used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ v0.5.3 (in development)
 -----------------------
 
 * Removed expensive server stats from the admin dashboard (#260).
+* Fixed bug in social account verification before linking it to an existing
+  local account (#262).
 
 
 v0.5.2 (2017-07-21)

--- a/pootle/apps/accounts/views.py
+++ b/pootle/apps/accounts/views.py
@@ -38,6 +38,12 @@ class SocialVerificationView(LoginView):
             'provider_name': self.sociallogin.account.get_provider().name,
         }
 
+    def get_form_class(self):
+        """Overridden to ensure SocialVerificationView's form is used, and not
+        the parent view's form.
+        """
+        return self.form_class
+
     def get_form_kwargs(self):
         kwargs = super(SocialVerificationView, self).get_form_kwargs()
         kwargs.update({


### PR DESCRIPTION
When the sign in view was switched to be customized via Allauth's own
form overridding method in 38f7e27, that made `SignInForm` to be used
all the time.

This can be explained by checking the parent Allauth-provided
`LoginView`'s logic to retrieve the form class to use:

> return get_form_class(app_settings.FORMS, 'login', self.form_class)

which will always give preference to the overriden login form specified
in the settings.

This commit modifies `SocialVerificationView` so that we ensure
`SocialVerificationForm` will always be used.