### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ assets:
 	npm --version
 	node --version
 	cd ${JS_DIR} && \
-	npm cache clear && \
+	npm cache verify && \
 	npm install && \
 	cd ${CWD}
 	${POOTLE_CMD} compilejsi18n

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ assets:
 	npm --version
 	node --version
 	cd ${JS_DIR} && \
-	npm cache verify && \
 	npm install && \
 	cd ${CWD}
 	${POOTLE_CMD} compilejsi18n


### PR DESCRIPTION
Using `npm cache clear` now breaks with the update of NPM 5 and above.
Using `npm cache verify` seems to solve the issue.