### PR TITLE
get_date_interval: reliably set the upper bound of the month

### DIFF
--- a/pootle/apps/pootle_misc/util.py
+++ b/pootle/apps/pootle_misc/util.py
@@ -7,6 +7,7 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import calendar
 from datetime import datetime, timedelta
 from functools import wraps
 from importlib import import_module
@@ -88,7 +89,11 @@ def get_date_interval(month):
 
     if start < now:
         if start.month != now.month or start.year != now.year:
-            end = get_max_month_datetime(start)
+            days_in_month = calendar.monthrange(start.year, start.month)[1]
+            tz = timezone.get_default_timezone()
+            end = tz.normalize(
+                start + timedelta(days=days_in_month),
+            )
     else:
         end = start
 


### PR DESCRIPTION
`get_max_month_datetime()` is buggy because it takes no DST transitions
into account: it simply increases 31 days, which should bring the date
to the next month. However, then date is localized to the server
timezone, which will shift the date to a different month and day when
there's a negative DST transition involved. Finally, the code will go
back 1 microsecond, incorrectly assuming the date refers to the first
day of the *next* month.

Because no DST transition is being taken into account, the calculated
end-of-the-month date would refer to the first day of the *current*
month when the month incurred in a DST transition, which would leave the
final date one month behind the expected result.

On the contrary, the new approach is reliable: by using the calendar
module the last day of the month is retrieved, which we can switch the
current date to while taking into account the possible DST changes in
the server timezone. This is taken care of by pytz's `normalize()`
function.

Quoting from the pytz documentation:

> In addition, if you perform date arithmetic on local times that cross
> DST boundaries, the result may be in an incorrect timezone (ie.
> subtract 1 minute from 2002-10-27 1:00 EST and you get 2002-10-27 0:59
> EST instead of the correct 2002-10-27 1:59 EDT). A normalize() method
> is provided to correct this.