### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ assets:
 	npm --version
 	node --version
 	cd ${JS_DIR} && \
-	npm cache clear && \
 	npm install && \
 	cd ${CWD}
 	${POOTLE_CMD} compilejsi18n


### PR DESCRIPTION
Using `npm cache clear` now breaks with the update of NPM 5 and above.

(Bringing this up from #264.)