### PR TITLE
Webpack: switch to babel-preset-env

### DIFF
--- a/pootle/static/js/.babelrc
+++ b/pootle/static/js/.babelrc
@@ -1,4 +1,4 @@
 {
   "plugins": ["rewire"],
-  "presets": ["es2015", "react"]
+  "presets": ["env", "react"]
 }

--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -15,7 +15,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.0",
     "babel-plugin-rewire": "^1.0.0-rc-7",
-    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.23.0",
     "babel-register": "^6.23.0",
     "bundle-loader": "^0.5.5",
@@ -30,6 +30,7 @@
     "style-loader": "^0.19.0",
     "stylelint": "^7.1.0",
     "stylelint-config-standard": "^12.0.0",
+    "uglifyjs-webpack-plugin": "^1.1.2",
     "webpack": "^3.10.0"
   },
   "dependencies": {

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -9,6 +9,10 @@
 
 var webpack = require('webpack');
 var path = require('path');
+// The uglifyjs plugin that comes along with webpack does not support minifying
+// ES2015+ code, so until it does starting in 4.0, we need to use this
+// webpack-contrib module.
+var UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 
 var env = process.env.NODE_ENV;
 var DEBUG = env !== 'production';
@@ -108,7 +112,9 @@ var plugins = [];
 
 if (!DEBUG) {
   plugins = [
-    new webpack.optimize.UglifyJsPlugin(),
+    new UglifyJsPlugin({
+      parallel: true,
+    }),
   ];
 } else {
   env = 'development';
@@ -160,7 +166,21 @@ var config = {
           babelrc: false,
           cacheDirectory: true,
           presets: [
-            require.resolve('babel-preset-es2015'),
+            [
+              require.resolve('babel-preset-env'), {
+                targets: {
+                  browsers: [
+                    "last 2 chrome versions",
+                    "last 2 firefox versions",
+                    "last 2 safari versions",
+                    "last 2 edge versions",
+                    "last 2 ios versions",
+                    "last 1 and_chr version",
+                    "last 1 and_uc version",
+                  ],
+                },
+              },
+            ],
             require.resolve('babel-preset-react'),
           ],
         },


### PR DESCRIPTION
This is encouraged over using ES201x presets.

Note we now require a separate UglifyJS plugin, because the one shipped
in the current stable version of Webpack doesn't understand ES201x
syntax. This will change starting in Webpack 4.0.