### PR TITLE
Editor: force-go instead of relying on implicit state

### DIFF
--- a/pootle/static/js/editor/UnitList.js
+++ b/pootle/static/js/editor/UnitList.js
@@ -97,8 +97,8 @@ class UnitsList {
     }
   }
 
-  goto(uid) {
-    if (uid === this.uid && this.idx !== this.total - 1) {
+  goto(uid, opts = { force: false }) {
+    if (uid === this.uid && !opts.force) {
       return;
     }
     this.uid = uid;

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -1652,7 +1652,7 @@ PTL.editor = {
                                ['filter', 'search', 'sfields', 'soptions'])
         );
       } else {
-        PTL.editor.units.goto(uid);
+        PTL.editor.units.goto(uid, { force: true });
       }
     }
     return true;


### PR DESCRIPTION
This one's more explicit than the previous solution.