### PR TITLE
Settings: consolidate and remove unused

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ v.next
   * `POOTLE_META_USERS` 
   * `POOTLE_CONTACT_ENABLED` (consolidated into `POOTLE_CONTACT_EMAIL`)
   * `PARSE_POOL_CULL_FREQUENCY` and `PARSE_POOL_SIZE` (moved to constants)
+  * `POOTLE_CACHE_TIMEOUT` (moved to a constant)
 
 
 v0.7.0 (2018-01-10)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,8 @@ v.next
     `test_checks` (#297)
 * Cleaned up unused settings:
   * `POOTLE_CUSTOM_TEMPLATE_CONTEXT` (#293)
-  * `POOTLE_META_USERS`
+  * `POOTLE_META_USERS` 
+  * `POOTLE_CONTACT_ENABLED` (consolidated into `POOTLE_CONTACT_EMAIL`)
 
 
 v0.7.0 (2018-01-10)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ v.next
     `test_checks` (#297)
 * Cleaned up unused settings:
   * `POOTLE_CUSTOM_TEMPLATE_CONTEXT` (#293)
+  * `POOTLE_META_USERS`
 
 
 v0.7.0 (2018-01-10)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ v.next
   * `POOTLE_CUSTOM_TEMPLATE_CONTEXT` (#293)
   * `POOTLE_META_USERS` 
   * `POOTLE_CONTACT_ENABLED` (consolidated into `POOTLE_CONTACT_EMAIL`)
+  * `PARSE_POOL_CULL_FREQUENCY` and `PARSE_POOL_SIZE` (moved to constants)
 
 
 v0.7.0 (2018-01-10)

--- a/docs/server/optimization.rst
+++ b/docs/server/optimization.rst
@@ -78,8 +78,6 @@ some tips for performance tuning on your Pootle installation.
 
 - Increase the cache timeout for users who are not logged in.
 
-- Increase your :setting:`PARSE_POOL_SIZE` if you have enough memory available.
-
 - Enable ``'django.contrib.sessions.backends.cached_db'``.
 
 - Disable swap on the server.  Things should be configured so that physical

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -106,22 +106,12 @@ Backend and caching settings.
 Site-specific settings.
 
 
-.. setting:: POOTLE_CONTACT_ENABLED
-
-``POOTLE_CONTACT_ENABLED``
-  Default: ``True``
-
-  Controls whether users will be able to use the contact form. The address to
-  receive messages is controlled by :setting:`POOTLE_CONTACT_EMAIL`.
-
-
 .. setting:: POOTLE_CONTACT_EMAIL
 
 ``POOTLE_CONTACT_EMAIL``
   Default: ``info@YOUR_DOMAIN.com``
 
-  Address to receive messages sent through the contact form. This will only
-  have effect if :setting:`POOTLE_CONTACT_ENABLED` is set to ``True``.
+  Address to receive messages sent through the contact form.
 
 
 .. setting:: POOTLE_CONTACT_REPORT_EMAIL

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -163,19 +163,6 @@ Configuration settings for applications used by Pootle.
   for the Pootle instance. Don't change this unless you know what you're
   doing.
 
-.. setting:: POOTLE_META_USERS
-
-``POOTLE_META_USERS``
-  Default: ``()``
-
-  .. versionadded:: 2.7
-
-  Additional meta, or non-human, accounts. Pootle already manages the 'system'
-  and 'nobody' users who own system updates to translations and submissions by
-  anonymous users.  These meta accounts have their own simple public profiles
-  and won't track scores.
-
-
 .. setting:: POOTLE_CAPTCHA_ENABLED
 
 ``POOTLE_CAPTCHA_ENABLED``

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -446,26 +446,6 @@ Translation environment configuration settings.
     For this service you need to `obtain a Yandex API key
     <https://tech.yandex.com/keys/get/?service=trnsl>`_.
 
-.. setting:: PARSE_POOL_CULL_FREQUENCY
-
-``PARSE_POOL_CULL_FREQUENCY``
-  Default: ``4``
-
-  When the pool fills up, 1/PARSE_POOL_CULL_FREQUENCY number of files will be
-  removed from the pool.
-
-
-.. setting:: PARSE_POOL_SIZE
-
-``PARSE_POOL_SIZE``
-  Default: ``40``
-
-  To avoid rereading and reparsing translation files from disk on
-  every request, Pootle keeps a pool of already parsed files in memory.
-
-  Larger pools will offer better performance, but higher memory usage
-  (per server process).
-
 
 .. setting:: POOTLE_TRANSLATION_DIRECTORY
 

--- a/docs/server/settings.rst
+++ b/docs/server/settings.rst
@@ -65,27 +65,6 @@ This file contains base configuration settings.
   The name of the Pootle server.
 
 
-20-backends.conf
-^^^^^^^^^^^^^^^^
-
-Backend and caching settings.
-
-
-.. setting:: POOTLE_CACHE_TIMEOUT
-
-``POOTLE_CACHE_TIMEOUT``
-  Default: ``604800`` (a week)
-
-  .. versionadded:: 2.7
-
-  Time in seconds to keep certain objects cached in memory (template fragments,
-  language and project lists, permissions, etc.).
-
-  Note that for anonymous users Pootle also uses :ref:`Django's caching
-  middleware <django:the-per-site-cache>`, and its settings can be configured
-  separately.
-
-
 25-logging.conf
 ^^^^^^^^^^^^^^^
 

--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -11,7 +11,6 @@ import datetime
 import re
 from hashlib import md5
 
-from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
@@ -141,8 +140,7 @@ class User(AbstractBaseUser):
     @cached_property
     def is_meta(self):
         """Returns `True` if this is a special fake user."""
-        return self.username in \
-            UserManager.META_USERS + settings.POOTLE_META_USERS
+        return self.username in UserManager.META_USERS
 
     @cached_property
     def email_hash(self):

--- a/pootle/apps/pootle_app/models/permissions.py
+++ b/pootle/apps/pootle_app/models/permissions.py
@@ -14,6 +14,8 @@ from django.core.cache import cache
 from django.db import models
 from django.utils.encoding import iri_to_uri
 
+from pootle.core.constants import CACHE_TIMEOUT
+
 
 def get_permission_contenttype():
     content_type = ContentType.objects.filter(app_label='pootle_app',
@@ -60,7 +62,7 @@ def get_permissions_by_username(username, directory):
         else:
             permissions_cache[pootle_path] = None
 
-        cache.set(key, permissions_cache, settings.POOTLE_CACHE_TIMEOUT)
+        cache.set(key, permissions_cache, CACHE_TIMEOUT)
 
     return permissions_cache[pootle_path]
 

--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -10,7 +10,6 @@
 import locale
 from collections import OrderedDict
 
-from django.conf import settings
 from django.core.cache import cache
 from django.db import models
 from django.db.models.signals import post_delete, post_save
@@ -19,6 +18,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.cache import make_method_key
+from pootle.core.constants import CACHE_TIMEOUT
 from pootle.core.mixins import TreeItem
 from pootle.core.url_helpers import get_editor_filter
 from pootle.i18n.gettext import language_dir, tr_lang
@@ -70,7 +70,7 @@ class LiveLanguageManager(models.Manager):
                        cmp=locale.strcoll,
                        key=lambda x: x[1])
             )
-            cache.set(key, languages, settings.POOTLE_CACHE_TIMEOUT)
+            cache.set(key, languages, CACHE_TIMEOUT)
 
         return languages
 

--- a/pootle/apps/pootle_misc/context_processors.py
+++ b/pootle/apps/pootle_misc/context_processors.py
@@ -48,10 +48,9 @@ def pootle_context(request):
         'settings': {
             'POOTLE_TITLE': settings.POOTLE_TITLE,
             'POOTLE_INSTANCE_ID': settings.POOTLE_INSTANCE_ID,
-            'POOTLE_CONTACT_ENABLED': (settings.POOTLE_CONTACT_ENABLED and
-                                       settings.POOTLE_CONTACT_EMAIL),
             'POOTLE_SIGNUP_ENABLED': settings.POOTLE_SIGNUP_ENABLED,
             'POOTLE_CACHE_TIMEOUT': settings.POOTLE_CACHE_TIMEOUT,
+            'CAN_CONTACT': bool(settings.POOTLE_CONTACT_EMAIL.strip()),
             'TZ': settings.TIME_ZONE,
             'TZ_OFFSET': TZ_OFFSET,
             'DEBUG': settings.DEBUG,

--- a/pootle/apps/pootle_misc/context_processors.py
+++ b/pootle/apps/pootle_misc/context_processors.py
@@ -10,6 +10,7 @@
 from django.conf import settings
 from django.utils import timezone, translation
 
+from pootle.core.constants import CACHE_TIMEOUT
 from pootle_language.models import Language
 from pootle_project.models import Project
 from staticpages.models import LegalPage
@@ -49,7 +50,7 @@ def pootle_context(request):
             'POOTLE_TITLE': settings.POOTLE_TITLE,
             'POOTLE_INSTANCE_ID': settings.POOTLE_INSTANCE_ID,
             'POOTLE_SIGNUP_ENABLED': settings.POOTLE_SIGNUP_ENABLED,
-            'POOTLE_CACHE_TIMEOUT': settings.POOTLE_CACHE_TIMEOUT,
+            'CACHE_TIMEOUT': CACHE_TIMEOUT,
             'CAN_CONTACT': bool(settings.POOTLE_CONTACT_EMAIL.strip()),
             'TZ': settings.TIME_ZONE,
             'TZ_OFFSET': TZ_OFFSET,

--- a/pootle/apps/pootle_project/models.py
+++ b/pootle/apps/pootle_project/models.py
@@ -13,7 +13,6 @@ from collections import OrderedDict
 
 from translate.filters import checks
 
-from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -25,6 +24,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from pootle.core.cache import make_method_key
+from pootle.core.constants import CACHE_TIMEOUT
 from pootle.core.mixins import CachedTreeItem
 from pootle.core.models import VirtualResource
 from pootle.core.url_helpers import (get_editor_filter, get_path_sortkey,
@@ -78,7 +78,7 @@ class ProjectManager(models.Manager):
             projects = OrderedDict(
                 (project.pop('code'), project) for project in projects_dict
             )
-            cache.set(cache_key, projects, settings.POOTLE_CACHE_TIMEOUT)
+            cache.set(cache_key, projects, CACHE_TIMEOUT)
 
         return projects
 
@@ -279,7 +279,7 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
                 allow_projects)).difference(forbid_projects)
 
         user_projects = list(user_projects)
-        cache.set(key, user_projects, settings.POOTLE_CACHE_TIMEOUT)
+        cache.set(key, user_projects, CACHE_TIMEOUT)
 
         return user_projects
 
@@ -329,7 +329,7 @@ class Project(models.Model, CachedTreeItem, ProjectURLMixin):
              in (set(stores.values_list("pootle_path", flat=True))
                  | set(dirs.values_list("pootle_path", flat=True)))},
             key=get_path_sortkey)
-        cache.set(cache_key, resources, settings.POOTLE_CACHE_TIMEOUT)
+        cache.set(cache_key, resources, CACHE_TIMEOUT)
         return resources
 
     # # # # # # # # # # # # # #  Methods # # # # # # # # # # # # # # # # # # #

--- a/pootle/apps/pootle_store/fields.py
+++ b/pootle/apps/pootle_store/fields.py
@@ -17,6 +17,7 @@ from translate.misc.multistring import multistring
 from django.db import models
 from django.db.models.fields.files import FieldFile, FileField
 
+from pootle.core.constants import PARSE_POOL_CULL_FREQUENCY, PARSE_POOL_SIZE
 from pootle.core.utils.multistring import (parse_multistring,
                                            unparse_multistring)
 
@@ -122,10 +123,8 @@ class TranslationStoreFieldFile(FieldFile):
     """
 
     from translate.misc.lru import LRUCachingDict
-    from django.conf import settings
 
-    _store_cache = LRUCachingDict(settings.PARSE_POOL_SIZE,
-                                  settings.PARSE_POOL_CULL_FREQUENCY)
+    _store_cache = LRUCachingDict(PARSE_POOL_SIZE, PARSE_POOL_CULL_FREQUENCY)
 
     def getpomtime(self):
         file_stat = os.stat(self.realpath)

--- a/pootle/apps/pootle_translationproject/models.py
+++ b/pootle/apps/pootle_translationproject/models.py
@@ -18,6 +18,7 @@ from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.functional import cached_property
 
+from pootle.core.constants import PARSE_POOL_CULL_FREQUENCY, PARSE_POOL_SIZE
 from pootle.core.mixins import CachedMethods, CachedTreeItem
 from pootle.core.url_helpers import get_editor_filter, split_pootle_path
 from pootle_app.models.directory import Directory
@@ -166,8 +167,8 @@ class TranslationProject(models.Model, CachedTreeItem):
     creation_time = models.DateTimeField(auto_now_add=True, db_index=True,
                                          editable=False, null=True)
 
-    _non_db_state_cache = LRUCachingDict(settings.PARSE_POOL_SIZE,
-                                         settings.PARSE_POOL_CULL_FREQUENCY)
+    _non_db_state_cache = LRUCachingDict(PARSE_POOL_SIZE,
+                                         PARSE_POOL_CULL_FREQUENCY)
 
     objects = TranslationProjectManager()
 

--- a/pootle/checks.py
+++ b/pootle/checks.py
@@ -191,16 +191,7 @@ def check_settings(app_configs=None, **kwargs):
             id="pootle.W007",
         ))
 
-    if not settings.POOTLE_CONTACT_EMAIL and settings.POOTLE_CONTACT_ENABLED:
-        errors.append(checks.Warning(
-            _("POOTLE_CONTACT_EMAIL is not set."),
-            hint=_("Set POOTLE_CONTACT_EMAIL to allow users to contact "
-                   "administrators through the Pootle contact form."),
-            id="pootle.W008",
-        ))
-
-    if settings.POOTLE_CONTACT_EMAIL in ("info@YOUR_DOMAIN.com") \
-       and settings.POOTLE_CONTACT_ENABLED:
+    if settings.POOTLE_CONTACT_EMAIL == "info@YOUR_DOMAIN.com":
         errors.append(checks.Warning(
             _("POOTLE_CONTACT_EMAIL is using the following default "
               "setting %r." % settings.POOTLE_CONTACT_EMAIL),
@@ -301,7 +292,7 @@ def check_email_server_is_alive(app_configs=None, **kwargs):
     from django.conf import settings
 
     errors = []
-    if settings.POOTLE_SIGNUP_ENABLED or settings.POOTLE_CONTACT_ENABLED:
+    if settings.POOTLE_SIGNUP_ENABLED or settings.POOTLE_CONTACT_EMAIL.strip():
         from django.core.mail import get_connection
 
         connection = get_connection()

--- a/pootle/core/constants.py
+++ b/pootle/core/constants.py
@@ -14,3 +14,8 @@
 # number of files will be removed from the pool.
 PARSE_POOL_SIZE = 40
 PARSE_POOL_CULL_FREQUENCY = 4
+
+# Certain items such as template fragments, permissions, language
+# and project names etc are cached. These are kept in memory for the duration in
+# seconds defined here.
+CACHE_TIMEOUT = 604800

--- a/pootle/core/constants.py
+++ b/pootle/core/constants.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Zing contributors.
+#
+# This file is a part of the Zing project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+# To avoid rereading and reparsing translation files from disk on
+# every request, Zing keeps a pool of already parsed files in memory.
+#
+# Larger pools will offer better performance, but higher memory usage
+# (per server process). When the pool fills up, 1/PARSE_POOL_CULL_FREQUENCY
+# number of files will be removed from the pool.
+PARSE_POOL_SIZE = 40
+PARSE_POOL_CULL_FREQUENCY = 4

--- a/pootle/settings/20-backends.conf
+++ b/pootle/settings/20-backends.conf
@@ -55,11 +55,6 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 # important, you can make this lower.
 CACHE_MIDDLEWARE_SECONDS = 600
 
-# Pootle caches certain items such as template fragments, permissions, language
-# and project names etc. These are kept in memory for the duration in seconds
-# defined here.
-POOTLE_CACHE_TIMEOUT = 604800
-
 
 #
 # Redis Queue

--- a/pootle/settings/30-site.conf
+++ b/pootle/settings/30-site.conf
@@ -20,9 +20,8 @@ DEBUG = False
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
 
-# Address to receive messages sent by contact form.
-POOTLE_CONTACT_EMAIL = 'info@YOUR_DOMAIN.com'
-POOTLE_CONTACT_ENABLED = True
+# Email address to receive messages sent by contact form.
+POOTLE_CONTACT_EMAIL = ''
 
 # By default Pootle uses SMTP server on localhost, if the server is
 # not configured for sending emails use these settings to setup an

--- a/pootle/settings/40-apps.conf
+++ b/pootle/settings/40-apps.conf
@@ -45,10 +45,6 @@ POOTLE_LEGALPAGE_NOCHECK_PREFIXES = (
     '/xhr',
 )
 
-# Pootle META users
-#
-# List of special 'API users'
-POOTLE_META_USERS = ()
 
 #
 # webassets

--- a/pootle/settings/60-translation.conf
+++ b/pootle/settings/60-translation.conf
@@ -11,17 +11,6 @@ POOTLE_TRANSLATION_DIRECTORY = working_path('translations')
 # want only the Pootle user to be able to read them.
 POOTLE_SYNC_FILE_MODE = 0644
 
-# File parse pool settings
-#
-# To avoid rereading and reparsing translation files from disk on
-# every request, Pootle keeps a pool of already parsed files in memory.
-#
-# Larger pools will offer better performance, but higher memory usage
-# (per server process). When the pool fills up, 1/PARSE_POOL_CULL_FREQUENCY
-# number of files will be removed from the pool.
-PARSE_POOL_SIZE = 40
-PARSE_POOL_CULL_FREQUENCY = 4
-
 
 # Set the backends you want to use to enable translation suggestions through
 # several online services. To disable this feature completely just comment all

--- a/pootle/settings/90-local.conf.template
+++ b/pootle/settings/90-local.conf.template
@@ -125,9 +125,8 @@ ADMINS = (
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email
 DEFAULT_FROM_EMAIL = 'info@YOUR_DOMAIN.com'
 
-# Address to receive messages sent by contact form.
+# Email address to receive messages sent by contact form.
 POOTLE_CONTACT_EMAIL = 'info@YOUR_DOMAIN.com'
-POOTLE_CONTACT_ENABLED = True
 
 # Email address to report string errors to, unless a report email was set for
 # the project for which the string error is being reported.

--- a/pootle/static/js/auth/index.js
+++ b/pootle/static/js/auth/index.js
@@ -19,7 +19,7 @@ import Auth from './containers/Auth';
 
 const mountNodeSelector = '.js-auth';
 const commonProps = {
-  canContact: PTL.settings.CONTACT_ENABLED,
+  canContact: PTL.settings.CAN_CONTACT,
   canRegister: PTL.settings.SIGNUP_ENABLED,
   socialAuthProviders: PTL.settings.SOCIAL_AUTH_PROVIDERS,
 };

--- a/pootle/templates/editor/export_view.html
+++ b/pootle/templates/editor/export_view.html
@@ -174,7 +174,7 @@
   <script type="text/javascript">
   window.PTL = window.PTL || {};
   PTL.settings = {
-    CONTACT_ENABLED: {{ settings.POOTLE_CONTACT_ENABLED|yesno:'true, false' }},
+    CAN_CONTACT: {{ settings.CAN_CONTACT|yesno:'true, false' }},
     SIGNUP_ENABLED: {{ settings.POOTLE_SIGNUP_ENABLED|yesno:'true, false' }},
     SOCIAL_AUTH_PROVIDERS: {{ SOCIAL_AUTH_PROVIDERS|to_js }},
   };

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -1,7 +1,7 @@
 {% load core i18n common_tags store_tags cleanhtml cache locale %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
-{% cache settings.POOTLE_CACHE_TIMEOUT unit_edit unit.id unit.mtime cantranslate cansuggest canreview altsrcs user.id LANGUAGE_CODE unit.terminology %}
+{% cache settings.CACHE_TIMEOUT unit_edit unit.id unit.mtime cantranslate cansuggest canreview altsrcs user.id LANGUAGE_CODE unit.terminology %}
 <td colspan="2" rowspan="1" class="js-editor-cell translate-full translate-focus{% if unit.isfuzzy %} fuzzy-unit{% endif %}" dir="{% locale_dir %}">
   <div class="unit-locked-lightbox js-unit-locked-lightbox">
     <div><div class="js-unit-locked-message"></div></div>

--- a/pootle/templates/help/quality_checks.html
+++ b/pootle/templates/help/quality_checks.html
@@ -9,7 +9,7 @@
 
   <p>Pootle has an ability to check for common translation mistakes. Once you submit a translation, it will compare its certain features with the original string and identify potential problems. Сhecks are displayed in the upper right corner, just above the submit button. Once there are checks in red, you will stay on the same unit, until you have each check resolved or muted. Note that you should only mute checks if you know what you're doing. Muted checks will be reviewed periodically by the managers.</p>
 
-  {% if settings.POOTLE_CONTACT_ENABLED %}
+  {% if settings.CAN_CONTACT %}
   <p>If you are not sure what a particular error means and how to fix it properly, use <i>"Report a problem with this string"</i> link at the top of the unit. The managers will try to assist you as soon as possible.</p>
   {% endif %}
 

--- a/pootle/templates/layout.html
+++ b/pootle/templates/layout.html
@@ -24,7 +24,7 @@
     <script type="text/javascript">
     window.PTL = window.PTL || {};
     PTL.settings = {
-      CONTACT_ENABLED: {{ settings.POOTLE_CONTACT_ENABLED|yesno:'true, false' }},
+      CAN_CONTACT: {{ settings.CAN_CONTACT|yesno:'true, false' }},
       SIGNUP_ENABLED: {{ settings.POOTLE_SIGNUP_ENABLED|yesno:'true, false' }},
       SOCIAL_AUTH_PROVIDERS: {{ SOCIAL_AUTH_PROVIDERS|to_js }},
       UI_LOCALE: '{{ LANGUAGE_CODE }}',
@@ -113,7 +113,7 @@
               <li><a href="{% url 'account_logout' %}"><i class="icon-exit"></i>{% trans 'Sign out' %}</a></li>
               <li class="menu-divider"></li>
               {% block nav_items_pre %}{% endblock %}
-              {% if settings.POOTLE_CONTACT_ENABLED %}
+              {% if settings.CAN_CONTACT %}
                 <li><a class="js-contact" href="{% url 'pootle-contact' %}">{% trans "Contact Us" %}</a></li>
               {% endif %}
               <li><a class="js-about-link" href="#">{% trans "About" %}</a></li>


### PR DESCRIPTION
Some unused settings have been removed:
* `POOTLE_META_USERS`

There have been simplifications too:
* `POOTLE_CONTACT_ENABLED` has been removed, in favor of using an email in `POOTLE_CONTACT_EMAIL`

And others have been moved to constants:
* `PARSE_POOL_CULL_FREQUENCY`, `PARSE_POOL_SIZE`
* `POOTLE_CACHE_TIMEOUT`