### PR TITLE
Webpack: convert into an npm script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ v.next
   * `dump`, `find_duplicate_emails`, `update_user_email` (#296)
   * `list_languages`, `list_projects`, `contributors`, `changed_languages`,
     `test_checks` (#297)
+  * `webpack`, which has been replaced by an `npm` script (#304).
 * Cleaned up unused settings:
   * `POOTLE_CUSTOM_TEMPLATE_CONTEXT` (#293)
   * `POOTLE_META_USERS` 

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,11 @@ build: docs assets
 	python setup.py sdist ${FORMATS} ${TAIL}
 
 assets:
-	npm --version
-	node --version
 	cd ${JS_DIR} && \
 	npm install && \
+	npm run build -- --display-error-details && \
 	cd ${CWD}
 	${POOTLE_CMD} compilejsi18n
-	${POOTLE_CMD} webpack --extra=--display-error-details
 	mkdir -p ${ASSETS_DIR}
 
 	${POOTLE_CMD} collectstatic --noinput --clear -i node_modules -i .tox -i docs ${TAIL}
@@ -37,16 +35,14 @@ assets:
 	chmod 664 ${ASSETS_DIR}/.webassets-cache/*
 
 travis-assets:
-	npm --version
-	node --version
 	if [ -d "${ASSETS_DIR}/.webassets-cache" ]; then \
 		echo "eating cache - yum!"; \
 	else \
 		cd ${JS_DIR} && \
 		npm install && \
+		npm run dev:nowatch && \
 		cd ${CWD}; \
 		${POOTLE_CMD} compilejsi18n; \
-		${POOTLE_CMD} webpack --dev --nowatch; \
 		mkdir -p ${ASSETS_DIR}; \
 		${POOTLE_CMD} collectstatic --noinput --clear -i node_modules -i .tox -i docs ${TAIL}; \
 		${POOTLE_CMD} assets build ${TAIL}; \

--- a/docs/server/commands.rst
+++ b/docs/server/commands.rst
@@ -555,25 +555,6 @@ to make these preparations using the command ``assets build``. This command is
 usually executed after the :ref:`collectstatic <commands#collectstatic>` one.
 
 
-.. django-admin:: webpack
-
-webpack
-^^^^^^^
-
-.. versionadded:: 2.7
-
-The `webpack <http://webpack.github.io/>`_ tool is used under the hood to
-bundle JavaScript scripts, and this management command is a convenient
-wrapper that sets everything up ready for production and makes sure to
-include any 3rd party customizations.
-
-.. django-admin-option:: --dev
-
-When the :option:`--dev` flag is enabled, development builds will be created
-and the process will start a watchdog to track any client-side scripts for
-changes. Use this only when developing Pootle.
-
-
 .. _commands#user-management:
 
 Managing users

--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -7,6 +7,9 @@
     "url": "git://github.com/evernote/zing.git"
   },
   "scripts": {
+    "build": "NODE_ENV=production webpack",
+    "dev": "webpack --progress --watch",
+    "dev:nowatch": "webpack --progress",
     "lint": "eslint .",
     "stylelint": "stylelint --config=stylelint.json ../css/**/*.css **/*.css",
     "test": "mocha --compilers js:babel-register --require setup.test.js \"./{,!(node_modules)/**/}*.test.js\""

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -67,45 +67,6 @@ var resolve = {
 };
 
 
-// Read extra `resolve.modules` paths from the `WEBPACK_ROOT` envvar
-// and merge the entry definitions from the manifest files
-var root = process.env.WEBPACK_ROOT;
-if (root !== undefined) {
-  var customPaths = root.split(';');
-  resolve.modules.push(path.join(__dirname, 'node_modules'));
-  customPaths.forEach(path => {
-    resolve.modules.push(path);
-  });
-
-  function mergeWithArrays(target, source) {
-    var rv = Object(target);
-    var value;
-    Object.getOwnPropertyNames(source).forEach(function (key) {
-      value = source[key];
-      // Merge values if a key exists both in source and target objects and the
-      // target contains an array
-      if (target.hasOwnProperty(key) && Array.isArray(target[key])) {
-        value = target[key].concat(source[key]);
-      }
-      rv[key] = value;
-    });
-
-    return rv;
-  }
-
-  for (var i=0; i<customPaths.length; i++) {
-    var customPath = customPaths[i];
-
-    try {
-      var manifestEntries = require(path.join(customPath, 'manifest.json'));
-      entries = mergeWithArrays(entries, manifestEntries);
-    } catch (e) {
-      console.error(e.message);
-    }
-  }
-}
-
-
 /* Plugins */
 
 var plugins = [];


### PR DESCRIPTION
Now that extra customization of the build pipeline is not needed, we can
remove the wrapper command around webpack.

If we need further integration or customization abilities in the future,
we should revisit the entire process, as the previous approach was
overly too complex.