### PR TITLE
Editor: avoid swapping textareas based on current values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 Zing Changelog
 ==============
 
+v.next
+------
+
+* Editor: fixed a bug where the Plurr editor would go away and miss its state
+  (#309).
+
+
 v0.8.0 (2018-01-29)
 -------------------
 

--- a/pootle/static/js/editor/components/Editor.js
+++ b/pootle/static/js/editor/components/Editor.js
@@ -12,9 +12,7 @@ import React from 'react';
 import { t } from 'utils/i18n';
 
 import EditingArea from '../components/EditingArea';
-import PlurrEditor from '../components/plurr/PlurrEditor';
-import RawFontTextarea from '../components/RawFontTextarea';
-import { getAreaId, detectFormat, Formats } from '../utils';
+import { getAreaId } from '../utils';
 
 
 const Editor = React.createClass({
@@ -27,6 +25,7 @@ const Editor = React.createClass({
     onChange: React.PropTypes.func.isRequired,
     style: React.PropTypes.object,
     targetNplurals: React.PropTypes.number.isRequired,
+    textareaComponent: React.PropTypes.func.isRequired,
     values: React.PropTypes.array,
   },
 
@@ -36,20 +35,8 @@ const Editor = React.createClass({
     };
   },
 
-  getTextareaComponent() {
-    // FIXME: load these on-demand
-    const { values } = this.props;
-    switch (detectFormat(values[0])) {
-      case Formats.PLURR:
-        return PlurrEditor;
-      default:
-        return RawFontTextarea;
-    }
-  },
-
   render() {
     const editingAreas = [];
-    const TextareaComponent = this.getTextareaComponent();
 
     for (let i = 0; i < this.props.targetNplurals; i++) {
       const extraProps = {};
@@ -67,7 +54,7 @@ const Editor = React.createClass({
               { t('Plural form %(index)s', { index: i }) }
             </div>
           }
-          <TextareaComponent
+          <this.props.textareaComponent
             autoFocus={i === 0}
             id={getAreaId(i)}
             initialValue={this.props.initialValues[i]}

--- a/pootle/static/js/editor/containers/EditorContainer.js
+++ b/pootle/static/js/editor/containers/EditorContainer.js
@@ -12,6 +12,9 @@ import React from 'react';
 import { qAll } from 'utils/dom';
 
 import Editor from '../components/Editor';
+import PlurrEditor from '../components/plurr/PlurrEditor';
+import RawFontTextarea from '../components/RawFontTextarea';
+import { detectFormat, Formats } from '../utils';
 
 
 const EditorContainer = React.createClass({
@@ -58,8 +61,23 @@ const EditorContainer = React.createClass({
     };
   },
 
+  componentWillMount() {
+    this.textareaComponent = this.getTextareaComponent();
+  },
+
   componentDidMount() {
     this.areas = qAll('.js-translation-area');
+  },
+
+  getTextareaComponent() {
+    // FIXME: load these on-demand
+    const { initialValues } = this.props;
+    switch (detectFormat(initialValues[0])) {
+      case Formats.PLURR:
+        return PlurrEditor;
+      default:
+        return RawFontTextarea;
+    }
   },
 
   getAreas() {
@@ -85,6 +103,7 @@ const EditorContainer = React.createClass({
         isRawMode={this.props.isRawMode}
         style={this.props.style}
         targetNplurals={this.props.targetNplurals}
+        textareaComponent={this.textareaComponent}
         initialValues={this.props.initialValues}
         onChange={this.handleChange}
         sourceValues={this.props.sourceValues}


### PR DESCRIPTION
The format and hence the textarea component to be used needs to be
calculated up-front in the container, and not in the editor component
based on current values' state. This caused components to be swapped as
translators typed, totally missing any internal state.