### PR TITLE
Codecov: disable PR comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,4 +2,4 @@ coverage:
   ignore:
     - "pytest_pootle/.*"
     - "tests/.*"
-comment: off
+comment: false


### PR DESCRIPTION
Apparently the config key value changed from `off` to `false`.