### PR TITLE
Invoices: explicitly check if a correction exists

### DIFF
--- a/tests/models/invoice.py
+++ b/tests/models/invoice.py
@@ -453,7 +453,8 @@ def test_invoice_get_total_amounts_extra_add(monkeypatch):
 
 
 def _check_single_paidtask(invoice, amount):
-    local_now = timezone.localtime(invoice.now)
+    server_tz = timezone.get_default_timezone()
+    local_now = timezone.localtime(invoice.now, server_tz)
     current_month_start = local_now.replace(day=1, hour=0, minute=0, second=0)
     PaidTask.objects.get(
         task_type=PaidTaskTypes.CORRECTION,


### PR DESCRIPTION
The `should_add_correction()` method was returning `True` even if adding
a correction wasn't necessary. This didn't have side-effects because
`add_correction()` was safeguarded with a `get_or_create()` call,
however that code-path shouldn't have been hit in that case.

Still, this broke a test -- why this issue didn't manifest before
remains a mystery. The contents of the failing test didn't make much
sense and it has been adjusted accordingly.

Historical note: my feeling is the first time the invoicing code was
ported, the test made sense, but afterwards (and probably in an amended
commit, which could have happened right before merging the feature after
a long hiatus) subtotals were added to the mix, which slightly changed
the logic.