### PR TITLE
User: `linkedin` field can be `None` too

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Zing Changelog
 v.next (not released yet)
 -------------------------
 
+* Fixed issue when saving users without linkedin accounts (#321).
 * Fixed issue where static pages wouldn't update their timestamps (#316).
 * Moved `LEGALPAGE_NOCHECK_PREFIXES` setting into a constant (#319).
 * Removed captcha middleware and associated setting (#315).

--- a/pootle/apps/pootle_app/forms.py
+++ b/pootle/apps/pootle_app/forms.py
@@ -104,7 +104,7 @@ class UserForm(forms.ModelForm):
 
     def clean_linkedin(self):
         url = self.cleaned_data['linkedin']
-        if url != '':
+        if url is not None and url != '':
             parsed = urlparse.urlparse(url)
             if 'linkedin.com' not in parsed.netloc or parsed.path == '/':
                 raise forms.ValidationError(


### PR DESCRIPTION
This fixes an issue that prevented from saving changes to users that
didn't indicate Linkedin account details.