### PR TITLE
Bugfix: fix UglifyJS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: false
 language: python
 env:
-  - TOXENV=py27-django111-sqlite PYTHONPATH=$HOME/virtualenv/python2.7.14/lib/python2.7/site-packages  TOX_TESTENV_PASSENV="PYTHONPATH"
-  - TOXENV=py27-django111-mysql PYTHONPATH=$HOME/virtualenv/python2.7.14/lib/python2.7/site-packages  TOX_TESTENV_PASSENV="PYTHONPATH"
-  - TOXENV=py27-django111-postgres PYTHONPATH=$HOME/virtualenv/python2.7.14/lib/python2.7/site-packages  TOX_TESTENV_PASSENV="PYTHONPATH"
+  - TOXENV=py27-django111-sqlite
+  - TOXENV=py27-django111-mysql
+  - TOXENV=py27-django111-postgres
   # Meta
-  - TOXENV=project PYTHONPATH=$HOME/virtualenv/python2.7.14/lib/python2.7/site-packages  TOX_TESTENV_PASSENV="PYTHONPATH"
+  - TOXENV=project
 cache:
   directories:
     - pootle/static/js/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,7 @@ cache:
     - pootle/static/js/node_modules
     - pootle/assets
 install:
-  - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then upgrade="--upgrade"; fi;
-      pip install $upgrade
-      -r requirements/base.txt
-      -r requirements/travis.txt
-      -e .
+  pip install tox===3.0.0
 script:
   - tox -e $TOXENV
 after_script:

--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -32,7 +32,7 @@
     "style-loader": "^0.19.0",
     "stylelint": "^7.1.0",
     "stylelint-config-standard": "^12.0.0",
-    "uglifyjs-webpack-plugin": "^1.1.2",
+    "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "^3.10.0"
   },
   "dependencies": {

--- a/pootle/static/js/webpack.config.js
+++ b/pootle/static/js/webpack.config.js
@@ -139,6 +139,7 @@ var config = {
                     "last 1 and_uc version",
                   ],
                 },
+                uglify: true,
               },
             ],
             require.resolve('babel-preset-react'),

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -3,7 +3,7 @@
 -r tests.txt
 -r _lint.txt
 
-tox>=2.3
+tox==3.0.0
 
 # Databases
 mysqlclient>=1.3.3

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -3,8 +3,6 @@
 -r tests.txt
 -r _lint.txt
 
-tox==3.0.0
-
 # Databases
 mysqlclient>=1.3.3
 psycopg2>=2.4.5

--- a/tests/models/invoice.py
+++ b/tests/models/invoice.py
@@ -487,7 +487,7 @@ def test_invoice_generate_add_correction(member, invoice_directory):
     INITIAL_SUBTOTAL = EVENT_COUNT * WORDCOUNT * TRANSLATION_RATE
     MINIMAL_PAYMENT = 20
 
-    month = get_previous_month()
+    month = timezone.datetime(2014, 04, 01)
     config = dict({
         'minimal_payment': MINIMAL_PAYMENT,
     }, **FAKE_CONFIG)
@@ -521,7 +521,8 @@ def test_invoice_generate_add_correction(member, invoice_directory):
     # Subsequent invoice generations must not add any corrections
     invoice.get_total_amounts.cache_clear()  # clears the LRU cache
     amounts = invoice.get_total_amounts()
-    assert amounts['total'] == INITIAL_SUBTOTAL
+    assert amounts['subtotal'] == 0
+    assert amounts['correction'] == INITIAL_SUBTOTAL * -1
     assert not invoice.should_add_correction(amounts['subtotal'])
     invoice.generate()
     _check_single_paidtask(invoice, INITIAL_SUBTOTAL)

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,9 @@ setenv=
     mysql: DATABASE_BACKEND=mysql_innodb
     sqlite: DATABASE_BACKEND=sqlite
     postgres: DATABASE_BACKEND=postgres
+deps=
+    -r {toxinidir}/requirements/base.txt
+    -r {toxinidir}/requirements/travis.txt
 commands=
     zing init
     make travis-assets

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps=
     -r {toxinidir}/requirements/base.txt
     -r {toxinidir}/requirements/travis.txt
 commands=
+    pip install -e .
     zing init
     make travis-assets
     py.test --cov-report=term --cov=. -v --duration=25
@@ -42,6 +43,7 @@ whitelist_externals=
 setenv=
     DATABASE_BACKEND=sqlite
 commands=
+    pip install -e .
     # Python code linting
     make lint-python
     # Setup databases


### PR DESCRIPTION
Setting a flag in `babel-preset-env` seems to be required now when newer packages are pulled.