### PR TITLE
Editor: provide fuzzy data when initializing units

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ v.next (not release yet)
 ------------------------
 
 * Enforced uniqueness of email addresses at the DB level (#295).
+* Editor: fixed a bug where view rows wouldn't expose proper styling (#329).
 
 
 v0.8.3 (2018-03-27)

--- a/pootle/static/js/editor/Unit.js
+++ b/pootle/static/js/editor/Unit.js
@@ -12,10 +12,11 @@ import { dir } from 'utils/i18n';
 class Unit {
 
   constructor({
-    id, source, sourceLang, target, targetLang,
+    id, isfuzzy, source, sourceLang, target, targetLang,
     targetLanguageName, projectName, file,
   }) {
     this.id = id;
+    this.isfuzzy = isfuzzy;
     this.source = source;
     this.sourceDir = dir(sourceLang);
     this.sourceLang = sourceLang;

--- a/pootle/static/js/editor/UnitList.js
+++ b/pootle/static/js/editor/UnitList.js
@@ -149,6 +149,7 @@ class UnitsList {
         const ctxData = {
           before: data.before.map(unitData => new Unit({
             id: unitData.id,
+            isfuzzy: unitData.isfuzzy,
             source: unitData.source,
             sourceLang: unitData.source_lang,
             target: unitData.target,
@@ -156,6 +157,7 @@ class UnitsList {
           })),
           after: data.after.map(unitData => new Unit({
             id: unitData.id,
+            isfuzzy: unitData.isfuzzy,
             source: unitData.source,
             sourceLang: unitData.source_lang,
             target: unitData.target,
@@ -258,6 +260,7 @@ class UnitsList {
           const unit = units[uid];
           this.units[uid] = new Unit({
             id: uid,
+            isfuzzy: unit.isfuzzy,
             source: unit.source,
             sourceLang: unit.source_lang,
             target: unit.target,


### PR DESCRIPTION
This fixes a bug where the view rows wouldn't be considered as fuzzy
until their full data was provided after visiting their edit views.