### PR TITLE
StaticPages: fix adding new pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Zing Changelog
 ==============
 
+v.next (unreleased)
+-------------------
+
+* Fixed bug which prevented adding static pages (#331).
+
+
 v0.8.4 (2018-04-23)
 -------------------
 

--- a/pootle/apps/staticpages/views.py
+++ b/pootle/apps/staticpages/views.py
@@ -79,7 +79,7 @@ class AdminTemplateView(SuperuserRequiredMixin, AdminCtxMixin, TemplateView):
 
 class PageCreateView(SuperuserRequiredMixin, AdminCtxMixin, PageModelMixin,
                      CreateView):
-    fields = ('title', 'virtual_path', 'active', 'url', 'body')
+    fields = ('title', 'virtual_path', 'active', 'body')
 
     success_url = reverse_lazy('pootle-staticpages')
     template_name = 'admin/staticpages/page_create.html'


### PR DESCRIPTION
The modelform referenced a no-longer existing field, which made the form
generating code crash.