### PR TITLE
Editor: implement shortcut for copying text from source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ v.next (unreleased)
 
 * Invoices: fixed an issue where the carry-over balance wouldn't be properly
   reported in emails (#332).
+* Editor: made copying from source text actually work (#333).
 
 
 v.0.8.5 (2018-05-02)

--- a/pootle/static/js/editor/app.js
+++ b/pootle/static/js/editor/app.js
@@ -344,6 +344,13 @@ PTL.editor = {
       this.gotoNext({ isSubmission: false });
     });
 
+    hotkeys.bind(['ctrl+alt+c'], (e) => {
+      e.preventDefault();
+      const sources = qAll('.js-copyoriginal');
+      const languageCode = sources[sources.length - 1].dataset.languageCode;
+      this.copyOriginal(languageCode);
+    });
+
     /* XHR activity indicator */
     $(document).ajaxStart(() => {
       clearTimeout(this.delayedActivityTimer);

--- a/pootle/static/js/shared/components/KeyboardHelpDialog.js
+++ b/pootle/static/js/shared/components/KeyboardHelpDialog.js
@@ -41,6 +41,7 @@ const HelpDialogContent = React.createClass({
 
     const modKey = macOS ? <kbd className="clover" /> : <kbd>Ctrl</kbd>;
     const ctrlKey = macOS ? <kbd>Control</kbd> : <kbd>Ctrl</kbd>;
+    const altKey = macOS ? <kbd>Option</kbd> : <kbd>Alt</kbd>;
     const shiftKey = <kbd>Shift</kbd>;
     const enterKey = <kbd>Enter</kbd>;
     const spaceKey = <kbd>Space</kbd>;
@@ -85,6 +86,10 @@ const HelpDialogContent = React.createClass({
                 {or}
                 {ctrlKey}{spaceKey}
               </td>
+            </tr>
+            <tr>
+              <td>{t('Copy original text to translation')}</td>
+              <td>{ctrlKey}{altKey}<kbd>c</kbd></td>
             </tr>
             </tbody>
           </table>

--- a/pootle/templates/editor/units/edit.html
+++ b/pootle/templates/editor/units/edit.html
@@ -110,7 +110,7 @@
                   <span class="js-mt-{{ altunit.language_code }}"></span>
                   <a class="icon-copy js-copyoriginal"
                      data-language-code="{{ altunit.language_code }}"
-                     title="{% trans 'Copy into translation' %}" accesskey="c"></a>
+                     title="{% trans 'Copy into translation' %}"></a>
                 </div>
                 {% endif %}
               </div>
@@ -132,7 +132,7 @@
                   <span class="js-mt-{{ source_language.code }}"></span>
                   <a class="icon-copy js-copyoriginal"
                      data-language-code="{{ source_language.code }}"
-                     title="{% trans 'Copy into translation' %}" accesskey="c"></a>
+                     title="{% trans 'Copy into translation' %}"></a>
                 </div>
                 {% endif %}
               </div>


### PR DESCRIPTION
The previous way didn't work consistently across browsers.