### PR TITLE
Invoices: add support to carry-over negative balances

### DIFF
--- a/pootle/apps/pootle_misc/util.py
+++ b/pootle/apps/pootle_misc/util.py
@@ -62,7 +62,7 @@ def ajax_required(f):
 
 
 def get_max_month_datetime(dt):
-    """Returns the datetime representing the last microsecond of the month with
+    """Returns the datetime representing the last second of the month with
     respect to the `dt` aware datetime.
     """
     days_in_month = calendar.monthrange(dt.year, dt.month)[1]
@@ -78,7 +78,7 @@ def get_max_month_datetime(dt):
     if new_dt.day != days_in_month:
         new_dt = new_dt.replace(day=days_in_month)
 
-    return new_dt.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return new_dt.replace(hour=23, minute=59, second=59, microsecond=0)
 
 
 def get_date_interval(month):
@@ -103,7 +103,7 @@ def get_date_interval(month):
     else:
         end = start
 
-    start = start.replace(hour=0, minute=0, second=0)
-    end = end.replace(hour=23, minute=59, second=59, microsecond=999999)
+    start = start.replace(hour=0, minute=0, second=0, microsecond=0)
+    end = end.replace(hour=23, minute=59, second=59, microsecond=0)
 
     return [start, end]

--- a/pootle/apps/reports/models/invoice.py
+++ b/pootle/apps/reports/models/invoice.py
@@ -369,20 +369,21 @@ class Invoice(object):
             minimum stipulated.
         * Side-effect: populates the object's `files` member.
         """
-        self._amounts = self._calculate_amounts()
+        amounts = self._calculate_amounts()
 
-        work_done = self.amounts['work_done']
+        work_done = amounts['work_done']
 
         if not self.is_carried_over and self.should_add_correction(work_done):
             self._add_carry_over(work_done)
 
-            self._amounts.update({
+            amounts.update({
                 'correction': work_done * -1,
                 'extra_amount': 0,
                 'balance': work_done,
                 'total': 0,
             })
 
+        self._amounts = amounts
         self.files = self._write_to_disk()
 
     def send_by_email(self, override_to=None, override_bcc=None):

--- a/pootle/apps/reports/models/invoice.py
+++ b/pootle/apps/reports/models/invoice.py
@@ -37,7 +37,7 @@ MONTH_FORMAT = '%Y-%m'
 def get_previous_month():
     """Returns the previous month as a datetime object."""
     return (
-        timezone.now().replace(day=1, hour=0, minute=0, second=0) -
+        timezone.now().replace(day=1, hour=0, minute=0, second=0, microsecond=0) -
         timedelta(days=1)
     )
 
@@ -263,7 +263,8 @@ class Invoice(object):
         """
         server_tz = timezone.get_default_timezone()
         local_now = timezone.localtime(self.now, server_tz)
-        initial_moment = local_now.replace(day=1, hour=0, minute=0, second=0)
+        initial_moment = local_now.replace(day=1, hour=0, minute=0, second=0,
+                                           microsecond=0)
 
         PaidTask.objects.get_or_create(
             task_type=PaidTaskTypes.CORRECTION,

--- a/pootle/apps/reports/models/invoice.py
+++ b/pootle/apps/reports/models/invoice.py
@@ -297,12 +297,11 @@ class Invoice(object):
 
         return True
 
-    @property
-    def needs_carry_over(self):
+    def needs_carry_over(self, subtotal):
         return (
             self.add_correction and
             not self.is_carried_over and
-            self.amounts['subtotal'] < self.conf.get('minimal_payment', 0)
+            subtotal < self.conf.get('minimal_payment', 0)
         )
 
     def get_context_data(self):
@@ -370,9 +369,9 @@ class Invoice(object):
         * Side-effect: populates the object's `files` member.
         """
         amounts = self._calculate_amounts()
+        subtotal = amounts['subtotal']
 
-        if self.needs_carry_over:
-            subtotal = amounts['subtotal']
+        if self.needs_carry_over(subtotal):
 
             self._add_carry_over(subtotal)
 

--- a/tests/models/invoice.py
+++ b/tests/models/invoice.py
@@ -514,9 +514,9 @@ def test_invoice_generate_add_carry_over(member, invoice_directory):
     amounts = invoice._calculate_amounts()
     assert amounts['subtotal'] == INITIAL_SUBTOTAL
     assert amounts['correction'] == 0
-    assert not amounts['is_carried_over']
     assert amounts['total'] == INITIAL_SUBTOTAL
     assert invoice.should_add_correction(amounts['subtotal'])
+    assert not invoice.is_carried_over
 
     # Generate an invoice first
     invoice.generate()
@@ -527,14 +527,14 @@ def test_invoice_generate_add_carry_over(member, invoice_directory):
     # Now numbers have been adjusted
     assert invoice.amounts['balance'] == INITIAL_SUBTOTAL
     assert invoice.amounts['correction'] == INITIAL_SUBTOTAL * -1  # carry-over
-    assert invoice.amounts['is_carried_over']
     assert invoice.amounts['total'] == 0
+
+    assert invoice.is_carried_over
 
     # Inspecting numbers doesn't alter anything
     amounts = invoice._calculate_amounts()
     assert amounts['subtotal'] == 0
     assert amounts['correction'] == INITIAL_SUBTOTAL * -1
-    assert amounts['is_carried_over']
     assert amounts['total'] == 0
     assert not invoice.should_add_correction(amounts['subtotal'])
 
@@ -546,9 +546,9 @@ def test_invoice_generate_add_carry_over(member, invoice_directory):
 
     assert amounts['subtotal'] == 0
     assert amounts['correction'] == INITIAL_SUBTOTAL * -1
-    assert amounts['is_carried_over']
     assert amounts['total'] == 0
     assert not invoice.should_add_correction(amounts['subtotal'])
+    assert invoice.is_carried_over
 
 
 @pytest.mark.django_db
@@ -597,7 +597,7 @@ def test_invoice_generate_negative_balance(member, invoice_directory):
     assert amounts['correction'] == CORRECTION
     assert amounts['total'] == SUBTOTAL
 
-    assert not amounts['is_carried_over']
+    assert not invoice.is_carried_over
 
     invoice.generate()
 
@@ -610,7 +610,7 @@ def test_invoice_generate_negative_balance(member, invoice_directory):
     assert invoice.amounts['total'] == 0
 
     assert not invoice.should_add_correction(invoice.amounts['subtotal'])
-    assert invoice.amounts['is_carried_over']
+    assert invoice.is_carried_over
 
 
 @pytest.mark.skip('The assertion needs to be part of a property')

--- a/tests/models/invoice.py
+++ b/tests/models/invoice.py
@@ -613,19 +613,15 @@ def test_invoice_generate_negative_balance(member, invoice_directory):
     assert invoice.is_carried_over
 
 
-@pytest.mark.skip('The assertion needs to be part of a property')
 @pytest.mark.django_db
-def test_invoice_get_context_data_empty_amounts(member):
-    """Tests getting the context data when amounts haven't been calculated
-    yet.
+def test_invoice_get_amounts(member):
+    """Tests accessing amounts when they haven't been calculated yet.
     """
     user = UserFactory.build()
     invoice = Invoice(user, FAKE_CONFIG)
 
-    assert invoice.amounts is None
-
     with pytest.raises(AssertionError):
-        invoice.get_context_data()
+        invoice.amounts
 
     invoice.generate()
 

--- a/tests/models/invoice.py
+++ b/tests/models/invoice.py
@@ -529,7 +529,7 @@ def test_invoice_generate_add_carry_over(member, invoice_directory):
     assert invoice.amounts['correction'] == INITIAL_SUBTOTAL * -1  # carry-over
     assert invoice.amounts['total'] == 0
 
-    assert not invoice.needs_carry_over
+    assert not invoice.needs_carry_over(invoice.amounts['subtotal'])
     assert invoice.is_carried_over
 
     # Inspecting numbers doesn't alter anything
@@ -548,7 +548,7 @@ def test_invoice_generate_add_carry_over(member, invoice_directory):
     assert invoice.amounts['correction'] == INITIAL_SUBTOTAL * -1
     assert invoice.amounts['total'] == 0
 
-    assert not invoice.needs_carry_over
+    assert not invoice.needs_carry_over(invoice.amounts['subtotal'])
     assert invoice.is_carried_over
 
 
@@ -610,7 +610,7 @@ def test_invoice_generate_negative_balance(member, invoice_directory):
     assert invoice.amounts['correction'] == SUBTOTAL * -1  # carry-over
     assert invoice.amounts['total'] == 0
 
-    assert not invoice.needs_carry_over
+    assert not invoice.needs_carry_over(invoice.amounts['subtotal'])
     assert invoice.is_carried_over
 
 

--- a/tests/models/invoice.py
+++ b/tests/models/invoice.py
@@ -458,7 +458,8 @@ def test_invoice_amounts_with_extra_add(member, monkeypatch):
 def _check_single_paidtask(invoice, amount):
     server_tz = timezone.get_default_timezone()
     local_now = timezone.localtime(invoice.now, server_tz)
-    current_month_start = local_now.replace(day=1, hour=0, minute=0, second=0)
+    current_month_start = local_now.replace(day=1, hour=0, minute=0, second=0,
+                                            microsecond=0)
     PaidTask.objects.get(
         task_type=PaidTaskTypes.CORRECTION,
         amount=(-1) * amount,

--- a/tests/models/invoice.py
+++ b/tests/models/invoice.py
@@ -551,6 +551,7 @@ def test_invoice_generate_add_carry_over(member, invoice_directory):
     assert not invoice.should_add_correction(amounts['subtotal'])
 
 
+@pytest.mark.skip('The assertion needs to be part of a property')
 @pytest.mark.django_db
 def test_invoice_get_context_data_empty_amounts(member):
     """Tests getting the context data when amounts haven't been calculated

--- a/tests/models/invoice.py
+++ b/tests/models/invoice.py
@@ -515,7 +515,7 @@ def test_invoice_generate_add_carry_over(member, invoice_directory):
     assert amounts['subtotal'] == INITIAL_SUBTOTAL
     assert amounts['correction'] == 0
     assert amounts['total'] == INITIAL_SUBTOTAL
-    assert invoice.should_add_correction(amounts['subtotal'])
+
     assert not invoice.is_carried_over
 
     # Generate an invoice first
@@ -529,6 +529,7 @@ def test_invoice_generate_add_carry_over(member, invoice_directory):
     assert invoice.amounts['correction'] == INITIAL_SUBTOTAL * -1  # carry-over
     assert invoice.amounts['total'] == 0
 
+    assert not invoice.needs_carry_over
     assert invoice.is_carried_over
 
     # Inspecting numbers doesn't alter anything
@@ -536,7 +537,6 @@ def test_invoice_generate_add_carry_over(member, invoice_directory):
     assert amounts['subtotal'] == 0
     assert amounts['correction'] == INITIAL_SUBTOTAL * -1
     assert amounts['total'] == 0
-    assert not invoice.should_add_correction(amounts['subtotal'])
 
     # Subsequent invoice generations must not add any corrections
     invoice.generate()
@@ -544,10 +544,11 @@ def test_invoice_generate_add_carry_over(member, invoice_directory):
     _check_single_paidtask(invoice, INITIAL_SUBTOTAL)
     assert PaidTask.objects.filter(task_type=PaidTaskTypes.CORRECTION).count() == 2
 
-    assert amounts['subtotal'] == 0
-    assert amounts['correction'] == INITIAL_SUBTOTAL * -1
-    assert amounts['total'] == 0
-    assert not invoice.should_add_correction(amounts['subtotal'])
+    assert invoice.amounts['subtotal'] == 0
+    assert invoice.amounts['correction'] == INITIAL_SUBTOTAL * -1
+    assert invoice.amounts['total'] == 0
+
+    assert not invoice.needs_carry_over
     assert invoice.is_carried_over
 
 
@@ -609,7 +610,7 @@ def test_invoice_generate_negative_balance(member, invoice_directory):
     assert invoice.amounts['correction'] == SUBTOTAL * -1  # carry-over
     assert invoice.amounts['total'] == 0
 
-    assert not invoice.should_add_correction(invoice.amounts['subtotal'])
+    assert not invoice.needs_carry_over
     assert invoice.is_carried_over
 
 

--- a/tests/utils/date.py
+++ b/tests/utils/date.py
@@ -28,23 +28,23 @@ def tz_name(request):
 @pytest.mark.parametrize('input, expected', [
     (
         datetime(2017, 3, 1, 23, 55, 0),
-        datetime(2017, 3, 31, 23, 59, 59, 999999),
+        datetime(2017, 3, 31, 23, 59, 59, 0),
     ),
     (
         datetime(2017, 4, 1, 23, 55, 0),
-        datetime(2017, 4, 30, 23, 59, 59, 999999),
+        datetime(2017, 4, 30, 23, 59, 59, 0),
     ),
     (
         datetime(2017, 10, 1, 0, 0, 0),
-        datetime(2017, 10, 31, 23, 59, 59, 999999),
+        datetime(2017, 10, 31, 23, 59, 59, 0),
     ),
     (
         datetime(2017, 11, 1, 0, 0, 0),
-        datetime(2017, 11, 30, 23, 59, 59, 999999),
+        datetime(2017, 11, 30, 23, 59, 59, 0),
     ),
     (
         datetime(2017, 12, 1, 0, 0, 0),
-        datetime(2017, 12, 31, 23, 59, 59, 999999),
+        datetime(2017, 12, 31, 23, 59, 59, 0),
     ),
 ])
 def test_get_max_month_datetime(input, expected, settings, tz_name):


### PR DESCRIPTION
Currently these were being omitted. Reporting of the remaining balance has been improved too.