### PR TITLE
Invoices: adjust carry-over wording

### DIFF
--- a/pootle/templates/invoices/no_invoice_message.html
+++ b/pootle/templates/invoices/no_invoice_message.html
@@ -16,7 +16,11 @@
 
     {% block body %}
     {% if is_carried_over %}
+      {% if balance < 0 %}
+      <p>This is to inform you that your balance at {{ ZING_TITLE }} is {{ balance }} {{ user.currency }}.</p>
+      {% else %}
       <p>This is to inform you that your balance at {{ ZING_TITLE }} is {{ balance }} {{ user.currency }}, which is less than the minimal payment of {{ minimal_payment }} {{ user.currency }} defined for your account.</p>
+      {% endif %}
       <p>Because of this, there will be no payments from us during this payment cycle. The amount of {{ balance }} {{ user.currency }} will be carried over to the next payment cycle. You will see two corrections in your statistics dashboard reflecting the carry-over (one in the previous month, and on in the current one).</p>
     {% else %}
     <p>


### PR DESCRIPTION
The reason for a carry-over can now be negative balance too (previously
it'd only be not reaching the minimal payment amount).