### PR TITLE
Due dates: exclude project paths in `for_project_path`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Zing Changelog
 v.next (unreleased)
 --------------------
 
+* Due dates: fixed deadlock when updating/deleting deadlines (#340).
 * Adding projects/languages via the UI won't trigger creation of translation
   projects and file scanning.
   This must be done via the management commands, which will take care of setting

--- a/pootle/models/duedate.py
+++ b/pootle/models/duedate.py
@@ -44,6 +44,8 @@ class DueDateQuerySet(models.QuerySet):
         xlang_regex = r'^%s$' % re.sub(r'^/projects/', '/[^/]*/', pootle_path)
         return self.filter(
             pootle_path__regex=xlang_regex,
+        ).exclude(
+            pootle_path__startswith='/projects/',
         )
 
     def for_language(self, language_code):


### PR DESCRIPTION
Because apart from language-specific paths this was returning project
paths, updating/deleting would acquire locks for such paths, but that
was already being modified (and hence locked) as part of the same
transaction when calling the `save()` and `delete()` methods of parent
classes.

Therefore excluding the project path from this method (which
semantically was incorrect) should fix the locking issue.