### PR TITLE
Top scorers: consider full days starting at midnight

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 Zing Changelog
 ==============
 
+v.next (unreleased)
+--------------------
+
+* Top scorers: the information will be provided taking entire days into account,
+  starting at midnight (#342).
+
+
 v0.8.7 (2018-05-29)
 --------------------
 

--- a/pootle/apps/accounts/models.py
+++ b/pootle/apps/accounts/models.py
@@ -173,7 +173,7 @@ class User(AbstractBaseUser):
         if top_scorers is not None:
             return top_scorers
 
-        now = timezone.now()
+        now = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
         past = now + datetime.timedelta(-days)
 
         lookup_kwargs = {


### PR DESCRIPTION
In some cases the DB might be hit multiple times because values are not
cached yet. With this change, we ensure the SQL queries will be
identical for a particular day, and as such at least the SQL cache can
be used.