### PR TITLE
Checks: avoid breakage with language-specific checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Zing Changelog
 v.next (unreleased)
 --------------------
 
+* Checks: fixed bug where language-specific checks would prevent check stats
+  from being loaded (#343).
 * Top scorers: the information will be provided taking entire days into account,
   starting at midnight (#342).
 

--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -1165,7 +1165,11 @@ def get_qc_data_by_name(check_name):
     try:
         return qc_dict[check_name]
     except KeyError:
-        return {}
+        return {
+            'code': check_name,
+            'is_critical': False,
+            'title': check_name,
+        }
 
 
 def _generic_check(str1, str2, regex, message):

--- a/tests/misc/checks.py
+++ b/tests/misc/checks.py
@@ -435,4 +435,8 @@ def test_get_qualitycheck_schema():
 ])
 def test_get_qc_data_by_name(fake_check_name):
     """Tests for invalid values in `get_qc_data_by_name`."""
-    assert get_qc_data_by_name(fake_check_name) == {}
+    assert get_qc_data_by_name(fake_check_name) == {
+        'code': fake_check_name,
+        'is_critical': False,
+        'title': fake_check_name,
+    }


### PR DESCRIPTION
The list of available quality checks doesn't include language-specific
checks, and with that, the information provided for the quality check is
incomplete (e.g. missing `is_critical` field).

Given TTK's nature, retrieving language-specific check information would
be way too complicated for the benefit it'd provide (especially given
that there are no language-specific checks which are critical), and
hence we'll simply provide the checks `name` and the `title` unchanged,
and use a `is_critical` value of `False`.