### PR TITLE
Fix building assets upon installation

### DIFF
--- a/pootle/apps/pootle_app/management/commands/build_assets.py
+++ b/pootle/apps/pootle_app/management/commands/build_assets.py
@@ -33,6 +33,7 @@ class Command(SkipChecksMixin, BaseCommand):
         )
         self.static_dir = os.path.join(self.pkg_dir, 'static')
         self.js_dir = os.path.join(self.static_dir, 'js')
+        self.target_dir = os.path.join(self.pkg_dir, 'assets')
 
         self.stdout.write('Building static files...')
 
@@ -65,9 +66,8 @@ class Command(SkipChecksMixin, BaseCommand):
         self._run(['npm', 'install', '--quiet'], cwd=self.js_dir)
 
     def _setup_dirs(self):
-        assets_dir = os.path.join(self.pkg_dir, 'assets')
         try:
-            os.mkdir(assets_dir)
+            os.mkdir(self.target_dir)
         except OSError:
             pass
 

--- a/pootle/apps/pootle_app/management/commands/build_assets.py
+++ b/pootle/apps/pootle_app/management/commands/build_assets.py
@@ -10,7 +10,6 @@ import logging
 import os
 from subprocess import check_output, CalledProcessError
 
-from django.conf import settings
 from django.core import management
 from django.core.management.base import BaseCommand, CommandError
 
@@ -85,12 +84,7 @@ class Command(SkipChecksMixin, BaseCommand):
             )
 
         management.call_command('compilejsi18n')
-        # HACK: temporarily modify where assets will be built to, otherwise
-        # `collectstatic` needs to be run twice
-        cfg_root = settings.STATIC_ROOT
-        settings.STATIC_ROOT = self.static_dir
-        management.call_command('assets', 'build')
-        settings.STATIC_ROOT = cfg_root
         management.call_command(
             'collectstatic', '--clear', '--noinput', '-i', 'node_modules'
         )
+        management.call_command('assets', 'build')

--- a/pootle/apps/pootle_app/management/commands/build_assets.py
+++ b/pootle/apps/pootle_app/management/commands/build_assets.py
@@ -87,4 +87,6 @@ class Command(SkipChecksMixin, BaseCommand):
         management.call_command(
             'collectstatic', '--clear', '--noinput', '-i', 'node_modules'
         )
-        management.call_command('assets', 'build')
+        manifest_file = os.path.join(self.static_dir, 'manifest.json')
+        management.call_command('assets', 'build', '--manifest',
+                                'json:%s' % manifest_file)

--- a/pootle/apps/pootle_app/management/commands/build_assets.py
+++ b/pootle/apps/pootle_app/management/commands/build_assets.py
@@ -84,6 +84,7 @@ class Command(SkipChecksMixin, BaseCommand):
                 'version is recent enough and retry.'
             )
 
+        management.call_command('compilejsi18n')
         # HACK: temporarily modify where assets will be built to, otherwise
         # `collectstatic` needs to be run twice
         cfg_root = settings.STATIC_ROOT

--- a/pootle/settings/40-apps.conf
+++ b/pootle/settings/40-apps.conf
@@ -12,6 +12,10 @@ ASSETS_DEBUG = False
 
 ASSETS_AUTO_BUILD = False
 
+ASSETS_MANIFEST = 'json:%s' % (
+    os.path.join(working_path('static'), 'manifest.json'),
+)
+
 
 #
 # Allauth

--- a/pootle/settings/40-apps.conf
+++ b/pootle/settings/40-apps.conf
@@ -6,24 +6,10 @@
 # webassets
 #
 
-# Whether to debug assets or not. Set to False in production environments
-# for better performance, but make sure 'cssmin' is installed.
-#
-# Valid options are True, False, and "merge".
-# You can set more configuration options for webassets if needed.
-# Read its documentation for further details:
+# Controls asset-related settings. Reference:
 #   http://elsdoerfer.name/docs/webassets/django/settings.html
 ASSETS_DEBUG = False
 
-# Controls whether bundles should be automatically built, and rebuilt, when
-# required (if set to True), or whether they must be built manually be the
-# user, for example via a management command.
-#
-# This is a good setting to have enabled during debugging, and can be very
-# convenient for low-traffic sites in production as well. However, there is a
-# cost in checking whether the source files have changed, so if you care about
-# performance, or if your build process takes very long, then you may want to
-# disable this.
 ASSETS_AUTO_BUILD = False
 
 


### PR DESCRIPTION
Also switches to using a manifest file, which should make things smoother and more predictable.