### PR TITLE
Cleanup: remove dead code

### DIFF
--- a/pootle/core/decorators.py
+++ b/pootle/core/decorators.py
@@ -243,36 +243,11 @@ def get_resource(func):
     @wraps(func)
     def wrapped(request, path_obj, dir_path, filename):
         """Gets resources associated to the current context."""
-        try:
-            directory = getattr(path_obj, 'directory', path_obj)
-            if directory.is_project() and (dir_path or filename):
-                set_project_resource(request, path_obj, dir_path, filename)
-            else:
-                set_resource(request, path_obj, dir_path, filename)
-        except Http404:
-            if not request.is_ajax():
-                user_choice = request.COOKIES.get('user-choice', None)
-                url = None
-
-                if hasattr(request, 'redirect_url'):
-                    url = request.redirect_url
-                elif user_choice in ('language', 'resource',):
-                    project = (path_obj
-                               if isinstance(path_obj, Project)
-                               else path_obj.project)
-                    url = reverse('pootle-project-browse',
-                                  args=[project.code, dir_path, filename])
-
-                if url is not None:
-                    response = redirect(url)
-
-                    if user_choice in ('language', 'resource',):
-                        # XXX: should we rather delete this in a single place?
-                        response.delete_cookie('user-choice')
-
-                    return response
-
-            raise Http404
+        directory = getattr(path_obj, 'directory', path_obj)
+        if directory.is_project() and (dir_path or filename):
+            set_project_resource(request, path_obj, dir_path, filename)
+        else:
+            set_resource(request, path_obj, dir_path, filename)
 
         return func(request, path_obj, dir_path, filename)
 

--- a/tests/core/decorators.py
+++ b/tests/core/decorators.py
@@ -125,9 +125,6 @@ def test_get_resource_tp(rf, default, tp0):
     store_name = 'store0.po'
     subdir_name = 'subdir0/'
 
-    subdir_name_fake = 'fake_subdir/'
-    store_name_fake = 'fake_store.po'
-
     request = rf.get('/')
     request.user = default
 
@@ -145,20 +142,6 @@ def test_get_resource_tp(rf, default, tp0):
     # TP, directory resource
     func(request, tp0, subdir_name, '')
     assert isinstance(request.resource_obj, Directory)
-
-    # TP, missing file/dir resource, redirects to parent resource
-    response = func(request, tp0, '', store_name_fake)
-    assert response.status_code == 302
-    assert tp0.pootle_path in response.get('location')
-
-    response = func(request, tp0, subdir_name, store_name_fake)
-    assert response.status_code == 302
-    assert (''.join([tp0.pootle_path, subdir_name]) in
-            response.get('location'))
-
-    response = func(request, tp0, subdir_name_fake, '')
-    assert response.status_code == 302
-    assert tp0.pootle_path in response.get('location')
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The redirect logic was applying to non-XHR requests, and in that context
there's no request being made to this endpoint.