### PR TITLE
Unbreak FAQ link

### DIFF
--- a/docs/workflow-overview.md
+++ b/docs/workflow-overview.md
@@ -13,7 +13,7 @@ and workflows.
 ### Interchange File Format
 
 For interchange purposes between external processes/workflows and the Zing
-translation database, Zing by design [only uses Gettext PO files](/faq).
+translation database, Zing by design [only uses Gettext PO files](https://evernote.github.io/zing/faq.html).
 This fits perfectly when [integrating with
 Serge](workflow-continuous-localization.md#continuous-localization-with-serge).
 


### PR DESCRIPTION
FAQ link is broken on https://evernote.github.io/zing/docs/workflow-overview
FAQ is stored in website/pages/en/faq.js 
This change at least fixes the link on *.github.io
(Feel free to tweak if same link can work both in github markdown viewer and github.io)