### PR TITLE
Bugfix: invalidate all languages list too

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ v.next (unreleased)
 -------------------
 
 * Tasks: removed limit of displaying 10 tasks.
+* Fixed bug where language list wouldn't be properly recalculated.
 
 
 v0.8.9 (2018-11-07)

--- a/pootle/apps/pootle_language/models.py
+++ b/pootle/apps/pootle_language/models.py
@@ -256,6 +256,9 @@ def clear_language_list_cache():
     key = make_method_key("LiveLanguageManager", "cached_dict", "*")
     cache.delete_pattern(key)
 
+    key_all = make_method_key("LiveLanguageManager", "all_cached_dict", "*")
+    cache.delete_pattern(key_all)
+
 
 @receiver([post_delete, post_save])
 def invalidate_language_list_cache(**kwargs):


### PR DESCRIPTION
The full language list wasn't being invalidated whenever there were
changes to existing languages.