### PR TITLE
Checks: implement line break checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Zing Changelog
 v.next (unreleased)
 -------------------
 
+* Checks: implemented line break checks (#410).
 * Tasks: sort by due dates (#413).
 * Tasks: removed limit of displaying 10 tasks.
 * Fixed bug where language list wouldn't be properly recalculated.

--- a/pootle/apps/pootle_misc/checks.py
+++ b/pootle/apps/pootle_misc/checks.py
@@ -265,6 +265,10 @@ plurr_format_regex = re.compile(u"{[^{}]*:.*?}")
 plurr_placeholders_regex = re.compile(u"{([^ {}:]*)", re.M)
 plurr_plural_suffix_regex = re.compile(u"_PLURAL$")
 
+linebreaks_single_regex = re.compile(r"(?<!\n)\n(?!\n)")
+linebreaks_double_regex = re.compile(r"(?<!\n)\n\n(?!\n)")
+linebreaks_multiple_regex = re.compile(r"(?<!\n)\n{3,}(?!\n)")
+
 
 def clean_plurr_placeholder(string):
     return plurr_plural_suffix_regex.sub("", string)
@@ -1063,6 +1067,39 @@ class ENChecker(checks.UnitChecker):
                 u"Placeholders missing in translation: %s"
                 % u", ".join(missing_in_translation)
             )
+
+        return True
+
+    @critical
+    def linebreaks_single(self, str1, str2, **kwargs):
+        source_parts_count = len(linebreaks_single_regex.split(str1))
+        target_parts_count = len(linebreaks_single_regex.split(str2))
+        if source_parts_count != target_parts_count:
+            raise checks.FilterFailure("Single line breaks mismatch")
+
+        return True
+
+    @critical
+    def linebreaks_double(self, str1, str2, **kwargs):
+        source_parts_count = len(linebreaks_double_regex.split(str1))
+        target_parts_count = len(linebreaks_double_regex.split(str2))
+        if source_parts_count != target_parts_count:
+            raise checks.FilterFailure("Double line breaks mismatch")
+
+        return True
+
+    @critical
+    def linebreaks_multiple(self, str1, str2, **kwargs):
+        source_counts = [
+            match.group().count("\n")
+            for match in linebreaks_multiple_regex.finditer(str1)
+        ]
+        target_counts = [
+            match.group().count("\n")
+            for match in linebreaks_multiple_regex.finditer(str2)
+        ]
+        if source_counts != target_counts:
+            raise checks.FilterFailure("Multiple line breaks mismatch")
 
         return True
 

--- a/tests/data/snapshots/test_translate/admin/_language0_project0_translate_.context.json
+++ b/tests/data/snapshots/test_translate/admin/_language0_project0_translate_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_language0_project0_translate_empty_dir0_.context.json
+++ b/tests/data/snapshots/test_translate/admin/_language0_project0_translate_empty_dir0_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_language0_project0_translate_empty_dir1_store6.po.context.json
+++ b/tests/data/snapshots/test_translate/admin/_language0_project0_translate_empty_dir1_store6.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_language0_project0_translate_store0.po.context.json
+++ b/tests/data/snapshots/test_translate/admin/_language0_project0_translate_store0.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_language0_project0_translate_subdir0_.context.json
+++ b/tests/data/snapshots/test_translate/admin/_language0_project0_translate_subdir0_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_language0_project0_translate_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_translate/admin/_language0_project0_translate_subdir0_store4.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_language0_translate_.context.json
+++ b/tests/data/snapshots/test_translate/admin/_language0_translate_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_projects_project0_translate_.context.json
+++ b/tests/data/snapshots/test_translate/admin/_projects_project0_translate_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_projects_project0_translate_empty_dir1_store6.po.context.json
+++ b/tests/data/snapshots/test_translate/admin/_projects_project0_translate_empty_dir1_store6.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_projects_project0_translate_store0.po.context.json
+++ b/tests/data/snapshots/test_translate/admin/_projects_project0_translate_store0.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_projects_project0_translate_subdir0_.context.json
+++ b/tests/data/snapshots/test_translate/admin/_projects_project0_translate_subdir0_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_projects_project0_translate_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_translate/admin/_projects_project0_translate_subdir0_store4.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/admin/_projects_translate_.context.json
+++ b/tests/data/snapshots/test_translate/admin/_projects_translate_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/member/_language0_project0_translate_.context.json
+++ b/tests/data/snapshots/test_translate/member/_language0_project0_translate_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/member/_language0_project0_translate_empty_dir0_.context.json
+++ b/tests/data/snapshots/test_translate/member/_language0_project0_translate_empty_dir0_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/member/_language0_project0_translate_empty_dir1_store6.po.context.json
+++ b/tests/data/snapshots/test_translate/member/_language0_project0_translate_empty_dir1_store6.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/member/_language0_project0_translate_store0.po.context.json
+++ b/tests/data/snapshots/test_translate/member/_language0_project0_translate_store0.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/member/_language0_project0_translate_subdir0_.context.json
+++ b/tests/data/snapshots/test_translate/member/_language0_project0_translate_subdir0_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/member/_language0_project0_translate_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_translate/member/_language0_project0_translate_subdir0_store4.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/member/_language0_translate_.context.json
+++ b/tests/data/snapshots/test_translate/member/_language0_translate_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_.context.json
+++ b/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_empty_dir0_.context.json
+++ b/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_empty_dir0_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_empty_dir1_store6.po.context.json
+++ b/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_empty_dir1_store6.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_store0.po.context.json
+++ b/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_store0.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_subdir0_.context.json
+++ b/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_subdir0_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_subdir0_store4.po.context.json
+++ b/tests/data/snapshots/test_translate/nobody/_language0_project0_translate_subdir0_store4.po.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/data/snapshots/test_translate/nobody/_language0_translate_.context.json
+++ b/tests/data/snapshots/test_translate/nobody/_language0_translate_.context.json
@@ -61,6 +61,18 @@
           "title": "Java-encoded unicode"
         },
         {
+          "code": "linebreaks_double",
+          "title": "linebreaks_double"
+        },
+        {
+          "code": "linebreaks_multiple",
+          "title": "linebreaks_multiple"
+        },
+        {
+          "code": "linebreaks_single",
+          "title": "linebreaks_single"
+        },
+        {
           "code": "mustache_like_placeholder_pairs",
           "title": "Mustache like placeholder pairs"
         },

--- a/tests/misc/checks.py
+++ b/tests/misc/checks.py
@@ -434,6 +434,130 @@ def test_plurr_placeholders(source_string, target_string, should_skip):
     assert_check(check, source_string, target_string, should_skip)
 
 
+@pytest.mark.parametrize(
+    "source_string, target_string, should_skip",
+    [
+        ("\n", "\n", True),
+        ("\n", "\n\n", False),
+        ("Foo\nbar", "La\nla", True),
+        ("Foo\nbar", "La\n\nla", False),
+        (
+            "The only thing I will leave after my\ndeath is a memory about me\n",
+            "Hilko banaiz,\nbalkoia zabalik utzi\n",
+            True,
+        ),
+        (
+            "The only thing I will leave after my\ndeath is a memory about me\n",
+            "Hilko banaiz, balkoia zabalik utzi\n",
+            False,
+        ),
+        (
+            "The only thing I will leave after my\ndeath is a memory about me\n",
+            "Hilko banaiz,\nbalkoia zabalik utzi",
+            False,
+        ),
+        (
+            "The only thing I will leave after my\ndeath is a memory about me\n",
+            "Hilko banaiz,\n\n\n\n\nbalkoia zabalik utzi",
+            False,
+        ),
+        (
+            "The only thing I will leave after my\ndeath is a memory about me\n",
+            "\nHilko banaiz,\n\n\n\n\nbalkoia zabalik utzi\n\n\n",
+            False,
+        ),
+    ],
+)
+def test_linebreaks_single(source_string, target_string, should_skip):
+    check = checker.linebreaks_single
+    assert_check(check, source_string, target_string, should_skip)
+
+
+@pytest.mark.parametrize(
+    "source_string, target_string, should_skip",
+    [
+        ("\n\n", "\n\n", True),
+        ("\n\n", "\n", False),
+        ("\n\n", "\n\n\n", False),
+        ("Foo\n\nbar", "La\n\nla", True),
+        ("Foo\n\nbar", "La\nla", False),
+        ("Foo\n\nbar", "La\n\n\nla", False),
+        (
+            "The only thing I will leave after my\n\ndeath is a memory about me\n",
+            "Hilko banaiz,\n\nbalkoia zabalik utzi\n",
+            True,
+        ),
+        (
+            "The only thing I will leave after my\n\ndeath is a memory about me\n",
+            "Hilko banaiz,\nbalkoia zabalik utzi\n",
+            False,
+        ),
+        (
+            "The only thing I will leave after my\n\ndeath is a memory about me\n",
+            "Hilko banaiz,\nbalkoia zabalik utzi",
+            False,
+        ),
+        (
+            "The only thing I will leave after my\n\ndeath is a memory about me\n",
+            "Hilko banaiz,\n\n\n\n\nbalkoia zabalik utzi",
+            False,
+        ),
+        (
+            "The only thing I will leave after my\n\ndeath is a memory about me\n",
+            "\nHilko banaiz,\n\n\n\n\nbalkoia zabalik utzi\n\n\n",
+            False,
+        ),
+    ],
+)
+def test_linebreaks_double(source_string, target_string, should_skip):
+    check = checker.linebreaks_double
+    assert_check(check, source_string, target_string, should_skip)
+
+
+@pytest.mark.parametrize(
+    "source_string, target_string, should_skip",
+    [
+        ("\n\n\n", "\n\n\n", True),
+        ("\n\n\n\n", "\n\n\n\n", True),
+        ("\n\n\n", "\n", False),
+        ("\n\n\n", "\n\n", False),
+        ("\n\n\n\n", "\n\n\n", False),
+        ("\n\n\n\n", "\n\n\n\n\n", False),
+        ("Foo\n\n\nbar", "La\n\n\nla", True),
+        ("Foo\n\n\nbar", "La\n\nla", False),
+        ("Foo\n\n\nbar", "La\n\n\n\nla", False),
+        (
+            "The only thing I will leave after my\n\n\ndeath is a memory about me\n\n\n\n",
+            "Hilko banaiz,\n\n\nbalkoia zabalik utzi\n\n\n\n",
+            True,
+        ),
+        (
+            "The only thing I will leave after my\n\n\ndeath is a memory about me\n\n",
+            "Hilko banaiz,\n\n\nbalkoia zabalik utzi",
+            True,
+        ),
+        (
+            "The only thing I will leave after my\n\n\n\ndeath is a memory about me\n\n",
+            "Hilko banaiz,\n\n\n\nbalkoia zabalik utzi",
+            True,
+        ),
+        (
+            "The only thing I will leave after my\n\n\ndeath is a memory about me\n\n\n\n",
+            "Hilko banaiz,\n\n\n\nbalkoia zabalik utzi\n\n\n",
+            False,
+        ),
+        (
+            "The only thing I will leave after my\n\n\ndeath is a memory about me\n\n\n",
+            "Hilko banaiz,\n\n\nbalkoia zabalik utzi",
+            False,
+        ),
+    ],
+)
+def test_linebreaks_multiple(source_string, target_string, should_skip):
+    check = checker.linebreaks_multiple
+    assert_check(check, source_string, target_string, should_skip)
+
+
 def test_get_qualitycheck_schema():
     d = {}
     checks = get_qualitychecks()


### PR DESCRIPTION
This accounts for single line breaks, double line breaks, and
3+ line breaks.

Fixes #410.