### PR TITLE
refresh_stats: don't process disabled projects by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ v.next (unreleased)
 * Tasks: sort by due dates (#413).
 * Tasks: removed limit of displaying 10 tasks.
 * Fixed bug where language list wouldn't be properly recalculated.
+* `refresh_stats` won't process disabled projects by default (#421).
 
 
 v0.8.9 (2018-11-07)

--- a/docs/ref-commands.md
+++ b/docs/ref-commands.md
@@ -221,8 +221,8 @@ are a couple more options to control how email will be sent:
 
 ### `refresh_stats`
 
-Recalculates all file statistics ensuring that they are up-to-date. Files in
-disabled projects are processed too.
+Recalculates all file statistics for active projects, ensuring they are
+up-to-date.
 
 A background process will create a task for every file to make sure calculated
 statistics data is up to date. When the task for a file completes then further
@@ -231,6 +231,11 @@ tasks will be created for the files' parents.
 > When users open a page that needs to
 display stats but they haven't been calculated yet, a banner will be displayed
 indicating that stats are out-of-date and in the process of being calculated.
+
+#### `--include-disabled-projects`
+
+By default, statistics for disabled projects are not calculated, and this can be
+changed by specifying `--include-disabled-projects`.
 
 
 ### `retry_failed_jobs`

--- a/pootle/apps/pootle_app/management/commands/__init__.py
+++ b/pootle/apps/pootle_app/management/commands/__init__.py
@@ -129,13 +129,13 @@ class PootleCommand(BaseCommand):
         if options["no_rq"]:
             set_sync_mode(options["noinput"])
 
-        if self.process_disabled_projects:
-            project_query = Project.objects.all()
-        else:
-            project_query = Project.objects.enabled()
-
         if self.projects:
-            project_query = project_query.filter(code__in=self.projects)
+            project_query = Project.objects.filter(code__in=self.projects)
+        else:
+            if self.process_disabled_projects:
+                project_query = Project.objects.all()
+            else:
+                project_query = Project.objects.enabled()
 
         for project in project_query.iterator():
             tp_query = project.translationproject_set.live().order_by("language__code")

--- a/pootle/apps/pootle_app/management/commands/refresh_stats.py
+++ b/pootle/apps/pootle_app/management/commands/refresh_stats.py
@@ -22,7 +22,23 @@ logger = logging.getLogger("stats")
 
 class Command(PootleCommand):
     help = "Allow stats and text indices to be refreshed manually."
-    process_disabled_projects = True
+    process_disabled_projects = False
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+
+        parser.add_argument(
+            "--include-disabled-projects",
+            action="store_true",
+            dest="disabled_projects",
+            default=False,
+            help="Process disabled projects",
+        )
+
+    def handle_all(self, **options):
+        self.__class__.process_disabled_projects = options["disabled_projects"]
+
+        super().handle_all(**options)
 
     def handle_all_stores(self, translation_project, **options_):
         stores = Store.objects.live().filter(translation_project=translation_project)


### PR DESCRIPTION
All existing projects can still be refreshed using the
`--include-disabled-projects` flag, and individual projects can also be
targetted via the `--project` argument.

Fixes #421.