### PR TITLE
refresh_stats: skip doing extra unnecessary work

### DIFF
--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -463,6 +463,17 @@ class CachedTreeItem(TreeItem):
             logger.warning("Cache for %s object cannot be updated.", self)
             self.unregister_all_dirty(decrement)
 
+        n_jobs = self.get_dirty_score()
+        if n_jobs > 1:
+            # Skip work if other jobs are scheduled to update this item later
+            self.unregister_all_dirty(decrement)
+            logger.debug("--> SKIP ITEM %s (pending jobs=%d)", self.cache_key, n_jobs)
+            return
+
+        logger.debug(
+            "--> UPDATE ITEM %s (pending jobs=%d)", self.cache_key, n_jobs,
+        )
+
         # children should be recalculated to avoid using of obsolete
         # directories or stores which could be saved in `children` property
         self.initialized = False


### PR DESCRIPTION
In the context of `refresh_stats`, directories with a large number of
stores end up doing a lot of unnecessary work, because each store
enqueue a job to calculate its stats, plus another job to calculate its
parent directory stats.

Such directories will attempt to concurrently work on calculating the
stats for the same item, and waste tons of resources.

With this commit, we will:
  1. skip any stats calculation if the amount of pending jobs for that
     item is > 1, i.e. bail out because other jobs will work on it
     later on.
  2. decrease the dirty counter in the item and in all parent path trail
     items to mark the job as processed.

The speed-up is substantial. When processing a directory with 583 stores
in a machine where 4 CPU cores are available and using 4 workers, we
decreased the processing time from 3:29 minutes to 37 seconds.

Things can also get worse because in order to safeguard from concurrent
updates and ensure atomicity, a key is watched as part of a Redis
pipeline, and if the watched key changes before the pipeline is executed
(~commit transaction), the operation is retried. While we are aware of
that behavior, none of that is addressed in this commit.