### PR TITLE
Revert "refresh_stats: skip doing extra unnecessary work"

### DIFF
--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -463,17 +463,6 @@ class CachedTreeItem(TreeItem):
             logger.warning("Cache for %s object cannot be updated.", self)
             self.unregister_all_dirty(decrement)
 
-        n_jobs = self.get_dirty_score()
-        if n_jobs > 1:
-            # Skip work if other jobs are scheduled to update this item later
-            self.unregister_all_dirty(decrement)
-            logger.debug("--> SKIP ITEM %s (pending jobs=%d)", self.cache_key, n_jobs)
-            return
-
-        logger.debug(
-            "--> UPDATE ITEM %s (pending jobs=%d)", self.cache_key, n_jobs,
-        )
-
         # children should be recalculated to avoid using of obsolete
         # directories or stores which could be saved in `children` property
         self.initialized = False


### PR DESCRIPTION
This reverts commit a5e1588c30068270790a02760b7738993d710795.

It turns out accessing the dirty score this way is not atomic, hence it
is unreliable when running with multiple worker processes. We'll revert
that changeset for the time being.