### PR TITLE
Bugfix: do not break access to individual units

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ v.next (unreleased)
 -------------------
 
 * Export view: allowed up to 1000 result rows (#230).
+* Editor: fixed bug where some individual units couldn't be accessed.
 * Ensured Sentry exceptions are captured for XHR views.
 
 

--- a/pootle/apps/pootle_store/unit/search.py
+++ b/pootle/apps/pootle_store/unit/search.py
@@ -158,7 +158,7 @@ class DBSearchBackend(object):
             uid_results = list(self.results.values_list("pk", "store_id"))
             uid_list = [result[0] for result in uid_results]
             if self.uid in uid_list:
-                begin = max(uid_list.index(self.uid) - MAX_RESULTS / 2, 0)
+                begin = max(uid_list.index(self.uid) - MAX_RESULTS // 2, 0)
                 end = min(begin + MAX_RESULTS, total)
                 uids = uid_results[begin:end]
 


### PR DESCRIPTION
In some cases, units couldn't be accessed because the index in the list
of UIDs would end up being a float. We will forcedfuly use integer
division for calculating indexes now.