### PR TITLE
Checks: do not include TTK quality checks page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ v.next (unreleased)
 
 * Export view: allowed up to 1000 result rows (#230).
 * Editor: fixed bug where some individual units couldn't be accessed.
+* Fixed access to quality checks help page (#431).
 * Ensured Sentry exceptions are captured for XHR views.
 
 

--- a/pootle/templates/help/quality_checks.html
+++ b/pootle/templates/help/quality_checks.html
@@ -7,7 +7,7 @@
 <div class="staticpage checks-descriptions" dir="ltr">
   <h1 class="title">Quality Checks</h1>
 
-  <p>Pootle has an ability to check for common translation mistakes. Once you submit a translation, it will compare its certain features with the original string and identify potential problems. Сhecks are displayed in the upper right corner, just above the submit button. Once there are checks in red, you will stay on the same unit, until you have each check resolved or muted. Note that you should only mute checks if you know what you're doing. Muted checks will be reviewed periodically by the managers.</p>
+  <p>Zing has an ability to check for common translation mistakes. Once you submit a translation, it will compare its certain features with the original string and identify potential problems. Сhecks are displayed in the upper right corner, just above the submit button. Once there are checks in red, you will stay on the same unit, until you have each check resolved or muted. Note that you should only mute checks if you know what you're doing. Muted checks will be reviewed periodically by the managers.</p>
 
   {% if settings.CAN_CONTACT %}
   <p>If you are not sure what a particular error means and how to fix it properly, use <i>"Report a problem with this string"</i> link at the top of the unit. The managers will try to assist you as soon as possible.</p>

--- a/pootle/templates/help/quality_checks.html
+++ b/pootle/templates/help/quality_checks.html
@@ -17,7 +17,5 @@
 
   {% include "help/_pootle_quality_checks.html" %}
 
-  {% include "help/_ttk_quality_checks.html" %}
-
 </div>
 {% endblock content %}

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ import re
 import sys
 from distutils import log
 from distutils.command.build import build as DistutilsBuild
-from distutils.core import Command
 from distutils.errors import DistutilsOptionError
 
 from setuptools import find_packages, setup
@@ -154,77 +153,6 @@ class PootleBuildMo(DistutilsBuild):
         self.build_mo()
 
 
-class BuildChecksTemplatesCommand(Command):
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        import django
-        import codecs
-        from pootle.apps.pootle_misc.checks import check_names, excluded_filters
-        from translate.filters.checks import (
-            TeeChecker,
-            StandardChecker,
-            StandardUnitChecker,
-        )
-
-        try:
-            from docutils.core import publish_parts
-        except ImportError:
-            from distutils.errors import DistutilsModuleError
-
-            raise DistutilsModuleError("Please install the docutils library.")
-        from pootle import syspath_override  # noqa
-
-        django.setup()
-
-        def get_check_description(name, filterfunc):
-            """Get a HTML snippet for a specific quality check description.
-
-            The quality check description is extracted from the check function
-            docstring (which uses reStructuredText) and rendered using docutils
-            to get the HTML snippet.
-            """
-            # Provide a header with an anchor to refer to.
-            description = '\n<h3 id="%s">%s</h3>\n\n' % (name, str(check_names[name]))
-
-            # Clean the leading whitespace on each docstring line so it gets
-            # properly rendered.
-            docstring = "\n".join(
-                line.strip() for line in filterfunc.__doc__.split("\n")
-            )
-
-            # Render the reStructuredText in the docstring into HTML.
-            description += publish_parts(docstring, writer_name="html")["body"]
-            return description
-
-        print("Regenerating Translate Toolkit quality checks descriptions")
-
-        # Get a checker with the Translate Toolkit checks. Note that filters
-        # that are not used in Pootle are excluded.
-        fd = TeeChecker(
-            checkerclasses=[StandardChecker, StandardUnitChecker]
-        ).getfilters(excludefilters=excluded_filters)
-
-        docs = sorted(get_check_description(name, f) for name, f in fd.items())
-
-        # Output the quality checks descriptions to the HTML file.
-        templates_dir = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)), "pootle", "templates"
-        )
-        filename = os.path.join(templates_dir, "help/_ttk_quality_checks.html")
-
-        with codecs.open(filename, "w", "utf-8") as f:
-            f.write(u"\n".join(docs))
-
-        print("Checks templates written to %r" % (filename))
-
-
 setup(
     name="Zing",
     version=__version__,
@@ -258,9 +186,5 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     entry_points={"console_scripts": ["zing = pootle.runner:main"]},
-    cmdclass={
-        "build_checks_templates": BuildChecksTemplatesCommand,
-        "build_mo": PootleBuildMo,
-        "test": PyTest,
-    },
+    cmdclass={"build_mo": PootleBuildMo, "test": PyTest},
 )


### PR DESCRIPTION
Because Zing uses its own set of checks already. Moreover, the page that
was trying to be included broke the page altogether because since Django
2.1 exceptions raised in templates are not silenced.

Fixes #431.