### PR TITLE
Improve treeitem module's test coverage

### DIFF
--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -272,20 +272,26 @@ class CachedTreeItem(TreeItem):
         """calculate stat value and update cached value"""
         start = datetime.now()
 
-        calc_fn = {
-            CachedMethods.WORDCOUNT_STATS: self._calc_wordcount_stats,
-            CachedMethods.SUGGESTIONS: self._calc_suggestion_count,
-            CachedMethods.LAST_ACTION: self._calc_last_action,
-            CachedMethods.LAST_UPDATED: self._calc_last_updated,
-            CachedMethods.CHECKS: self._calc_checks,
-            CachedMethods.MTIME: self._calc_mtime,
-        }.get(name, lambda: None)
+        value = None
 
-        self.set_cached_value(name, calc_fn())
+        if name == str(CachedMethods.WORDCOUNT_STATS):
+            value = self._calc_wordcount_stats()
+        elif name == str(CachedMethods.SUGGESTIONS):
+            value = self._calc_suggestion_count()
+        elif name == str(CachedMethods.LAST_ACTION):
+            value = self._calc_last_action()
+        elif name == str(CachedMethods.LAST_UPDATED):
+            value = self._calc_last_updated()
+        elif name == str(CachedMethods.CHECKS):
+            value = self._calc_checks()
+        elif name == str(CachedMethods.MTIME):
+            value = self._calc_mtime()
+
+        self.set_cached_value(name, value)
 
         end = datetime.now()
         ctx = {
-            "function": calc_fn.__name__,
+            "function": name.replace("get_", "_calc_"),
             "time": end - start,
             "key": self.cache_key,
         }

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -374,7 +374,7 @@ class CachedTreeItem(TreeItem):
     def mark_dirty(self, *args):
         """Mark cached method names for this TreeItem as dirty"""
         for key in args:
-            self._dirty_cache.add(key)
+            self._dirty_cache.add(str(key))
 
     def mark_all_dirty(self):
         """Mark all cached method names for this TreeItem as dirty"""

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -9,6 +9,7 @@
 
 import logging
 from datetime import datetime
+from enum import Enum
 
 from redis import WatchError
 from rq import get_current_job
@@ -42,24 +43,23 @@ class NoCachedStats(Exception):
     pass
 
 
-class CachedMethods(object):
+class CachedMethods(Enum):
     """Cached method names."""
 
     CHECKS = "get_checks"
-    WORDCOUNT_STATS = "get_wordcount_stats"
     LAST_ACTION = "get_last_action"
-    SUGGESTIONS = "get_suggestion_count"
-    MTIME = "get_mtime"
     LAST_UPDATED = "get_last_updated"
+    MTIME = "get_mtime"
+    SUGGESTIONS = "get_suggestion_count"
+    WORDCOUNT_STATS = "get_wordcount_stats"
 
-    # Check refresh_stats command when add a new CachedMethod
+    def __str__(self):
+        return str(self.value)
 
     @classmethod
     def get_all(cls):
-        return [
-            getattr(cls, x)
-            for x in [x for x in dir(cls) if x[:2] != "__" and x != "get_all"]
-        ]
+        """Retrieves all cached method names as a list."""
+        return [str(e) for e in cls]
 
 
 class TreeItem(object):

--- a/tests/core/mixins/treeitem.py
+++ b/tests/core/mixins/treeitem.py
@@ -15,23 +15,57 @@ from pootle_project.models import Project
 from pootle_store.models import Store
 from pootle_translationproject.models import TranslationProject
 
+ALL_CACHED_METHODS = [
+    "get_checks",
+    "get_last_action",
+    "get_last_updated",
+    "get_mtime",
+    "get_suggestion_count",
+    "get_wordcount_stats",
+]
+
 
 def test_cachedmethods_get_all():
     """Retrieval of all cached methods as a list."""
-    ALL_CACHED_METHODS = [
-        "get_checks",
-        "get_last_action",
-        "get_last_updated",
-        "get_mtime",
-        "get_suggestion_count",
-        "get_wordcount_stats",
-    ]
     assert CachedMethods.get_all() == ALL_CACHED_METHODS
 
 
 def test_cachedmethods_str():
     """Make sure coercion to str() prints enum's value."""
     assert str(CachedMethods.WORDCOUNT_STATS) == "get_wordcount_stats"
+
+
+def test_cachedtreeitem_mark_dirty_single():
+    """Mark dirty a single method."""
+    cti = CachedTreeItem()
+
+    method = CachedMethods.WORDCOUNT_STATS
+    expected_value = [str(CachedMethods.WORDCOUNT_STATS)]
+
+    cti.mark_dirty(method)
+    assert cti._dirty_cache == set(expected_value)
+
+
+def test_cachedtreeitem_mark_dirty_list():
+    """Mark dirty multiple methods."""
+    cti = CachedTreeItem()
+
+    methods = [CachedMethods.WORDCOUNT_STATS, CachedMethods.LAST_ACTION]
+    expected_value = [
+        str(CachedMethods.WORDCOUNT_STATS),
+        str(CachedMethods.LAST_ACTION),
+    ]
+
+    cti.mark_dirty(*methods)
+    assert cti._dirty_cache == set(expected_value)
+
+
+def test_cachedtreeitem_mark_all_dirty():
+    """Mark dirty all methods."""
+    cti = CachedTreeItem()
+
+    cti.mark_all_dirty()
+    assert cti._dirty_cache == set(ALL_CACHED_METHODS)
 
 
 def test_cachedtreeitem_get_set_cached_value():

--- a/tests/core/mixins/treeitem.py
+++ b/tests/core/mixins/treeitem.py
@@ -29,6 +29,11 @@ def test_cachedmethods_get_all():
     assert CachedMethods.get_all() == ALL_CACHED_METHODS
 
 
+def test_cachedmethods_str():
+    """Make sure coercion to str() prints enum's value."""
+    assert str(CachedMethods.WORDCOUNT_STATS) == "get_wordcount_stats"
+
+
 def test_cachedtreeitem_get_set_cached_value():
     """Setting/getting cached values via method names."""
     cti = CachedTreeItem()

--- a/tests/core/mixins/treeitem.py
+++ b/tests/core/mixins/treeitem.py
@@ -9,7 +9,7 @@
 
 import pytest
 
-from pootle.core.mixins.treeitem import CachedMethods
+from pootle.core.mixins.treeitem import CachedMethods, CachedTreeItem
 from pootle_app.models import Directory
 from pootle_project.models import Project
 from pootle_store.models import Store
@@ -27,6 +27,18 @@ def test_cachedmethods_get_all():
         "get_wordcount_stats",
     ]
     assert CachedMethods.get_all() == ALL_CACHED_METHODS
+
+
+def test_cachedtreeitem_get_set_cached_value():
+    """Setting/getting cached values via method names."""
+    cti = CachedTreeItem()
+    cti.pootle_path = "/test/path/"  # dummy value required for `cache_key`
+
+    method = CachedMethods.WORDCOUNT_STATS
+    expected_value = "test_value"
+
+    cti.set_cached_value(method, expected_value)
+    assert cti.get_cached_value(method) == expected_value
 
 
 @pytest.mark.django_db

--- a/tests/core/mixins/treeitem.py
+++ b/tests/core/mixins/treeitem.py
@@ -9,10 +9,24 @@
 
 import pytest
 
+from pootle.core.mixins.treeitem import CachedMethods
 from pootle_app.models import Directory
 from pootle_project.models import Project
 from pootle_store.models import Store
 from pootle_translationproject.models import TranslationProject
+
+
+def test_cachedmethods_get_all():
+    """Retrieval of all cached methods as a list."""
+    ALL_CACHED_METHODS = [
+        "get_checks",
+        "get_last_action",
+        "get_last_updated",
+        "get_mtime",
+        "get_suggestion_count",
+        "get_wordcount_stats",
+    ]
+    assert CachedMethods.get_all() == ALL_CACHED_METHODS
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
* Makes `CachedMethods` an enum and adds tests
* Adds some `CachedTreeItem` tests