### PR TITLE
Language: do not count disabled items for totals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Zing Changelog
 ==============
 
+v.next (unreleased)
+-------------------
+
+* Fixed bug where no overview stats were shown for language pages (#425).
+
+
 v0.9.1 (2020-03-11)
 -------------------
 

--- a/pootle/core/mixins/treeitem.py
+++ b/pootle/core/mixins/treeitem.py
@@ -132,13 +132,19 @@ class TreeItem(object):
     def _calc_suggestion_count(self):
         self.initialize_children()
         return self._get_suggestion_count() + sum(
-            [item.get_cached(CachedMethods.SUGGESTIONS) for item in self.children]
+            [
+                item.get_cached(CachedMethods.SUGGESTIONS)
+                for item in self.children
+                if not getattr(item, "disabled", False)
+            ]
         )
 
     def _calc_wordcount_stats(self):
         result = self._get_wordcount_stats()
         self.initialize_children()
         for item in self.children:
+            if getattr(item, "disabled", False):
+                continue
             result = dictsum(result, item.get_cached(CachedMethods.WORDCOUNT_STATS))
 
         return result
@@ -148,7 +154,11 @@ class TreeItem(object):
 
         return max(
             [self._get_last_action()]
-            + [item.get_cached(CachedMethods.LAST_ACTION) for item in self.children],
+            + [
+                item.get_cached(CachedMethods.LAST_ACTION)
+                for item in self.children
+                if not getattr(item, "disabled", False)
+            ],
             key=lambda x: x["mtime"] if "mtime" in x else 0,
         )
 
@@ -157,7 +167,11 @@ class TreeItem(object):
         self.initialize_children()
         return max(
             [self._get_mtime()]
-            + [item.get_cached(CachedMethods.MTIME) for item in self.children]
+            + [
+                item.get_cached(CachedMethods.MTIME)
+                for item in self.children
+                if not getattr(item, "disabled", False)
+            ]
         )
 
     def _calc_last_updated(self):
@@ -165,13 +179,19 @@ class TreeItem(object):
         self.initialize_children()
         return max(
             [self._get_last_updated()]
-            + [item.get_cached(CachedMethods.LAST_UPDATED) for item in self.children],
+            + [
+                item.get_cached(CachedMethods.LAST_UPDATED)
+                for item in self.children
+                if not getattr(item, "disabled", False)
+            ],
         )
 
     def _calc_checks(self):
         result = self._get_checks()
         self.initialize_children()
         for item in self.children:
+            if getattr(item, "disabled", False):
+                continue
             item_res = item.get_cached(CachedMethods.CHECKS)
             result["checks"] = dictsum(result["checks"], item_res["checks"])
             result["unit_critical_error_count"] += item_res["unit_critical_error_count"]

--- a/tests/data/snapshots/test_browse/admin/_language0_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_language0_.context.json
@@ -67,8 +67,8 @@
         "treeitem_type": 2
       }
     },
-    "critical": 23,
-    "fuzzy": 1005,
+    "critical": 18,
+    "fuzzy": 740,
     "lastaction": {
       "displayname": "Member",
       "email": "a4fae232e2bfebd9f4dc8d7cb6caecb2",
@@ -79,9 +79,9 @@
       "uid": 134,
       "username": "member"
     },
-    "suggestions": 69,
-    "total": 3457,
-    "translated": 1187
+    "suggestions": 54,
+    "total": 2602,
+    "translated": 897
   },
   "can_admin_due_dates": false,
   "can_translate": true,

--- a/tests/data/snapshots/test_browse/admin/_projects_.context.json
+++ b/tests/data/snapshots/test_browse/admin/_projects_.context.json
@@ -4,23 +4,8 @@
   "browsing_data": {
     "children": {
       "/projects/disabled_project0/": {
-        "critical": 5,
-        "fuzzy": 265,
         "is_disabled": true,
-        "lastaction": {
-          "displayname": "Member",
-          "email": "a4fae232e2bfebd9f4dc8d7cb6caecb2",
-          "mtime": 1578661826,
-          "source": "Translated Source /language0/disabled_project0/su\u2026",
-          "translation_action_type": 1,
-          "type": 1,
-          "uid": 162,
-          "username": "member"
-        },
-        "suggestions": 15,
         "title": "Disabled Project 0",
-        "total": 855,
-        "translated": 290,
         "treeitem_type": 2
       },
       "/projects/project0/": {
@@ -67,8 +52,8 @@
         "treeitem_type": 2
       }
     },
-    "critical": 41,
-    "fuzzy": 1745,
+    "critical": 36,
+    "fuzzy": 1480,
     "lastaction": {
       "displayname": "Member",
       "email": "a4fae232e2bfebd9f4dc8d7cb6caecb2",
@@ -79,9 +64,9 @@
       "uid": 142,
       "username": "member"
     },
-    "suggestions": 123,
-    "total": 5957,
-    "translated": 2017
+    "suggestions": 108,
+    "total": 5102,
+    "translated": 1727
   },
   "can_admin_due_dates": false,
   "can_translate": true,

--- a/tests/data/snapshots/test_stats_checks/admin/_language0_.response_body.json
+++ b/tests/data/snapshots/test_stats_checks/admin/_language0_.response_body.json
@@ -1,13 +1,13 @@
 [
   {
     "code": "c_format",
-    "count": 23,
+    "count": 18,
     "is_critical": true,
     "title": "C format placeholders"
   },
   {
     "code": "percent_sign_placeholders",
-    "count": 23,
+    "count": 18,
     "is_critical": true,
     "title": "Percent sign placeholders"
   },

--- a/tests/data/snapshots/test_stats_checks/admin/_projects_.response_body.json
+++ b/tests/data/snapshots/test_stats_checks/admin/_projects_.response_body.json
@@ -1,13 +1,13 @@
 [
   {
     "code": "c_format",
-    "count": 41,
+    "count": 36,
     "is_critical": true,
     "title": "C format placeholders"
   },
   {
     "code": "percent_sign_placeholders",
-    "count": 41,
+    "count": 36,
     "is_critical": true,
     "title": "Percent sign placeholders"
   },

--- a/tests/data/snapshots/test_stats_checks/member/_language0_.response_body.json
+++ b/tests/data/snapshots/test_stats_checks/member/_language0_.response_body.json
@@ -1,13 +1,13 @@
 [
   {
     "code": "c_format",
-    "count": 23,
+    "count": 18,
     "is_critical": true,
     "title": "C format placeholders"
   },
   {
     "code": "percent_sign_placeholders",
-    "count": 23,
+    "count": 18,
     "is_critical": true,
     "title": "Percent sign placeholders"
   },

--- a/tests/data/snapshots/test_stats_checks/nobody/_language0_.response_body.json
+++ b/tests/data/snapshots/test_stats_checks/nobody/_language0_.response_body.json
@@ -1,13 +1,13 @@
 [
   {
     "code": "c_format",
-    "count": 23,
+    "count": 18,
     "is_critical": true,
     "title": "C format placeholders"
   },
   {
     "code": "percent_sign_placeholders",
-    "count": 23,
+    "count": 18,
     "is_critical": true,
     "title": "Percent sign placeholders"
   },


### PR DESCRIPTION
This fixes a bug where language pages wouldn't display any total numbers
if there were disabled projects without calculated stats (note this is
now the default for `refresh_stats`).

In a follow-up change we'll need to make sure this behavior can be
toggled so that browsing views can still get the total counts that
include disabled projects.

Refs. #425.