### PR TITLE
Docs: preprocess version from package.json

### DIFF
--- a/docs/start-installation.md
+++ b/docs/start-installation.md
@@ -30,7 +30,7 @@ environment is active.
 Use `pip` to install Zing into the virtual environment:
 
 ```shell
-pip install https://github.com/evernote/zing/archive/v0.8.8.zip
+pip install https://github.com/evernote/zing/archive/v|version|.zip
 ```
 
 This will also fetch and install Zing's dependencies.
@@ -41,7 +41,7 @@ the `zing` command line tool within your environment.
 
 ```shell
 zing --version
-Zing |release|
+Zing |version|
 ```
 
 Now you are ready to [perform the initial setup](start-setup.md).

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,9 @@
     "examples": "docusaurus-examples",
     "start": "docusaurus-start",
     "build": "docusaurus-build",
+    "prepublish-gh-pages": "sh ./version.sh",
     "publish-gh-pages": "docusaurus-publish",
+    "postpublish-gh-pages": "git checkout ../docs/",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version"

--- a/website/version.sh
+++ b/website/version.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+PACKAGE_JSON=../pootle/static/js/package.json
+DOCS=../docs/*.md
+VERSION=`grep '"version"' $PACKAGE_JSON | awk '{print $2}' | sed -e 's/[",]//g'`
+
+sed -i "" -e "s/|version|/$VERSION/g" $DOCS


### PR DESCRIPTION
This will replace any occurrences of |version| in the Markdown documents
in docs/ with the actual Zing version number.