### PR TITLE
get_editor_filter: add support for `all` query string

### DIFF
--- a/pootle/core/url_helpers.py
+++ b/pootle/core/url_helpers.py
@@ -124,6 +124,7 @@ def get_editor_filter(
     search=None,
     sfields=None,
     check_category=None,
+    include_disabled=None,
 ):
     """Return a filter string to be appended to a translation URL."""
     filter_string = ""
@@ -150,6 +151,9 @@ def get_editor_filter(
             filter_string += "&sort=%s" % sort
         else:
             filter_string = "#sort=%s" % sort
+
+    if include_disabled:
+        filter_string += filter_string and "&all" or "#all"
 
     return filter_string
 

--- a/tests/core/url_helpers.py
+++ b/tests/core/url_helpers.py
@@ -83,6 +83,10 @@ def test_split_pootle_path():
             dict(search="Foo: bar.po\nID: 1", sfields="locations"),
             "#search=Foo%3A+bar.po%0AID%3A+1&sfields=locations",
         ),
+        (dict(include_disabled=False), ""),
+        (dict(include_disabled=True), "#all"),
+        (dict(state="translated", include_disabled=False), "#filter=translated"),
+        (dict(state="translated", include_disabled=True), "#filter=translated&all"),
     ],
 )
 def test_get_editor_filter(kwargs, expected):

--- a/tests/core/url_helpers.py
+++ b/tests/core/url_helpers.py
@@ -6,6 +6,8 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
+import pytest
+
 from pootle.core.url_helpers import (
     get_all_pootle_paths,
     get_editor_filter,
@@ -65,27 +67,24 @@ def test_split_pootle_path():
     )
 
 
-def test_get_editor_filter():
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        (dict(state="untranslated"), "#filter=untranslated"),
+        (dict(state="untranslated", sort="newest"), "#filter=untranslated&sort=newest"),
+        (dict(sort="newest"), "#sort=newest"),
+        (dict(state="all", search="Foo", sfields="locations"), "#filter=all"),
+        (dict(search="Foo", sfields="locations"), "#search=Foo&sfields=locations"),
+        (
+            dict(search="Foo", sfields=["locations", "notes"]),
+            "#search=Foo&sfields=locations,notes",
+        ),
+        (
+            dict(search="Foo: bar.po\nID: 1", sfields="locations"),
+            "#search=Foo%3A+bar.po%0AID%3A+1&sfields=locations",
+        ),
+    ],
+)
+def test_get_editor_filter(kwargs, expected):
     """Tests editor filters are correctly constructed."""
-    assert get_editor_filter(state="untranslated") == "#filter=untranslated"
-    assert (
-        get_editor_filter(state="untranslated", sort="newest")
-        == "#filter=untranslated&sort=newest"
-    )
-    assert get_editor_filter(sort="newest") == "#sort=newest"
-    assert (
-        get_editor_filter(state="all", search="Foo", sfields="locations")
-        == "#filter=all"
-    )
-    assert (
-        get_editor_filter(search="Foo", sfields="locations")
-        == "#search=Foo&sfields=locations"
-    )
-    assert (
-        get_editor_filter(search="Foo", sfields=["locations", "notes"])
-        == "#search=Foo&sfields=locations,notes"
-    )
-    assert (
-        get_editor_filter(search="Foo: bar.po\nID: 1", sfields="locations")
-        == "#search=Foo%3A+bar.po%0AID%3A+1&sfields=locations"
-    )
+    assert get_editor_filter(**kwargs) == expected


### PR DESCRIPTION
Plus extra parametrized tests.