### PR TITLE
getTranslateUrl: fixes to avoid double slashes

### DIFF
--- a/pootle/static/js/shared/utils/url.js
+++ b/pootle/static/js/shared/utils/url.js
@@ -72,12 +72,20 @@ export function getResourcePath(path) {
  * @param {string} path - internal path
  */
 export function getTranslateUrl(path, { check, filter } = {}) {
-  const pathItems = path.split('/'); // path starts with the slash
-  pathItems.shift(); // remove the first empty item
-  const lang = pathItems.shift();
-  const project = pathItems.shift();
+  const [languageCode, projectCode, dirPath, filename] = splitPootlePath(path);
 
-  const url = `/${lang}/${project}/translate/${pathItems.join('/')}`;
+  let url;
+  if (languageCode && projectCode) {
+    url = `/${languageCode}/${projectCode}`;
+  } else if (languageCode) {
+    url = `/${languageCode}`;
+  } else if (projectCode) {
+    url = `/projects/${projectCode}`;
+  } else {
+    url = '/projects';
+  }
+
+  url += `/translate/${dirPath + filename}`;
 
   if (filter) {
     return `${url}#filter=${filter}`;

--- a/pootle/static/js/shared/utils/url.test.js
+++ b/pootle/static/js/shared/utils/url.test.js
@@ -9,7 +9,7 @@
 import expect from 'expect';
 import { describe, it } from 'mocha';
 
-import { split, splitPootlePath } from './url';
+import { split, splitPootlePath, getTranslateUrl } from './url';
 
 
 describe('url', () => {
@@ -132,6 +132,38 @@ describe('url', () => {
       tests.forEach(test => {
         expect(splitPootlePath(test.path)).toEqual(test.expected);
       });
+    });
+  });
+
+  it('constructs translate URLs from internal paths', () => {
+    const tests = [
+      {
+        path: '/',
+        expected: '/projects/translate/',
+      },
+      {
+        path: '/ru/',
+        expected: '/ru/translate/',
+      },
+      {
+        path: '/ru/foo/bar/baz.po',
+        expected: '/ru/foo/translate/bar/baz.po',
+      },
+      {
+        path: '/projects/foo/',
+        expected: '/projects/foo/translate/',
+      },
+      {
+        path: '/projects/foo/bar/baz',
+        expected: '/projects/foo/translate/bar/baz',
+      },
+      {
+        path: '/projects/foo/bar/baz/blah.po',
+        expected: '/projects/foo/translate/bar/baz/blah.po',
+      },
+    ];
+    tests.forEach(test => {
+      expect(getTranslateUrl(test.path)).toEqual(test.expected);
     });
   });
 });


### PR DESCRIPTION
Some of the URLs being generated included two consecutive slashes. This change makes `getTranslateUrl()` more robust by internally leveraging `splitPootlePath()`.