### PR TITLE
Travis: simplify project config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,11 @@ jobs:
         # Python code linting
         - make lint-python
         # Migrate and initdb
-        - bash -c "DATABASE_BACKEND=sqlite python manage.py migrate --noinput --traceback"
-        - bash -c "DATABASE_BACKEND=sqlite python manage.py initdb --no-projects"
-        - bash -c "DATABASE_BACKEND=sqlite python manage.py makemigrations --noinput --check"
+        - python manage.py migrate --noinput --traceback
+        - python manage.py initdb --no-projects
+        - python manage.py makemigrations --noinput --check
         # Other tasks
-        - zing init
-        - zing build_assets
+        - python manage.py build_assets
         - python setup.py sdist
         - make docs
 


### PR DESCRIPTION
There's no need to pass environment variables via `bash -c` because this
is already set by Travis. Likewise, we can resource to using `python
manage.py` all the time to avoid an extra `init` command.