### PR TITLE
Fix a bunch of frontend translate URLs

### DIFF
--- a/pootle/static/js/browser/components/BrowserTableRow.js
+++ b/pootle/static/js/browser/components/BrowserTableRow.js
@@ -68,8 +68,6 @@ const BrowserTableRow = React.createClass({
       total,
       translated,
     } = this.props;
-    const translateUrl = getTranslateUrl(pootlePath);
-
     const trClasses = cx('item', {
       'is-disabled': isDisabled,
       'is-empty': total === 0,
@@ -105,7 +103,7 @@ const BrowserTableRow = React.createClass({
         </td>
         <td className="stats-graph">{progressBar}</td>
         <td className="stats-number total">
-          <a href={translateUrl} className="stats-data">
+          <a href={getTranslateUrl(pootlePath)} className="stats-data">
             <ColoredNumber n={total} />
           </a>
         </td>
@@ -115,16 +113,19 @@ const BrowserTableRow = React.createClass({
         <td className="stats-number critical">
           <NumberPill
             n={critical}
-            url={`${translateUrl}#filter=checks&category=critical`}
+            url={getTranslateUrl(pootlePath, { checksCategory: 'critical' })}
           />
         </td>
         <td className="stats-number suggestions">
-          <NumberPill n={suggestions} url={`${translateUrl}#filter=suggestions`} />
+          <NumberPill
+            n={suggestions}
+            url={getTranslateUrl(pootlePath, { filter: 'suggestions' })}
+          />
         </td>
         <td className="stats-number need-translation">
           <NumberPill
             n={total - translated}
-            url={`${translateUrl}#filter=incomplete`}
+            url={getTranslateUrl(pootlePath, { filter: 'incomplete' })}
           />
         </td>
         <td className="last-activity">

--- a/pootle/static/js/browser/components/FailingChecksTable.js
+++ b/pootle/static/js/browser/components/FailingChecksTable.js
@@ -39,7 +39,7 @@ const CheckRow = ({ check, canTranslate, pootlePath }) => {
 
   let url = '';
   if (canTranslate) {
-    url = getTranslateUrl(pootlePath, { check: check.code });
+    url = getTranslateUrl(pootlePath, { checks: check.code });
   }
 
   const props = { canTranslate, url };

--- a/pootle/static/js/browser/components/TaskItem.js
+++ b/pootle/static/js/browser/components/TaskItem.js
@@ -48,14 +48,14 @@ const TaskItem = ({
   type,
 }) => {
   let label;
-  let actionUrl = getTranslateUrl(path);
+  let actionUrl;
 
   if (type === 'critical') {
     label = t('Fix critical errors');
-    actionUrl = `${actionUrl}#filter=checks&category=critical`;
+    actionUrl = getTranslateUrl(path, { checksCategory: 'critical' });
   } else {
     label = t('Finish translation');
-    actionUrl = `${actionUrl}#filter=incomplete`;
+    actionUrl = getTranslateUrl(path, { filter: 'incomplete' });
   }
 
   const dueDateMsg = dateFormatter.format(dueOnMsEpoch);

--- a/pootle/static/js/browser/components/TranslateActions.js
+++ b/pootle/static/js/browser/components/TranslateActions.js
@@ -36,7 +36,6 @@ Action.propTypes = {
 
 const TranslateActions = ({ areActionsEnabled, pootlePath, stats }) => {
   const { critical, suggestions, total, translated } = stats;
-  const translateUrl = areActionsEnabled ? getTranslateUrl(pootlePath) : '';
   return (
     <ul>
       {critical > 0 && (
@@ -47,7 +46,11 @@ const TranslateActions = ({ areActionsEnabled, pootlePath, stats }) => {
               areActionsEnabled ? t('Fix critical errors') : t('Critical errors')
             }
             count={critical}
-            url={translateUrl}
+            url={
+              areActionsEnabled
+                ? getTranslateUrl(pootlePath, { checksCategory: 'critical' })
+                : ''
+            }
           />
         </li>
       )}
@@ -57,7 +60,11 @@ const TranslateActions = ({ areActionsEnabled, pootlePath, stats }) => {
             name="review-suggestions"
             caption={areActionsEnabled ? t('Review suggestions') : t('Suggestions')}
             count={suggestions}
-            url={translateUrl}
+            url={
+              areActionsEnabled
+                ? getTranslateUrl(pootlePath, { filter: 'suggestions' })
+                : ''
+            }
           />
         </li>
       )}
@@ -69,7 +76,11 @@ const TranslateActions = ({ areActionsEnabled, pootlePath, stats }) => {
               areActionsEnabled ? t('Continue translation') : t('Incomplete')
             }
             count={total - translated}
-            url={translateUrl}
+            url={
+              areActionsEnabled
+                ? getTranslateUrl(pootlePath, { filter: 'incomplete' })
+                : ''
+            }
           />
         </li>
       )}
@@ -79,7 +90,7 @@ const TranslateActions = ({ areActionsEnabled, pootlePath, stats }) => {
             name="translation-complete"
             caption={areActionsEnabled ? t('View all') : t('All')}
             count={total}
-            url={translateUrl}
+            url={areActionsEnabled ? getTranslateUrl(pootlePath) : ''}
           />
         </li>
       )}

--- a/pootle/static/js/shared/utils/url.js
+++ b/pootle/static/js/shared/utils/url.js
@@ -68,7 +68,7 @@ export function getResourcePath(path) {
  * Retrieves a translation URL out of an internal `path`
  * @param {string} path - internal path
  */
-export function getTranslateUrl(path, { check, filter } = {}) {
+export function getTranslateUrl(path, { checks, filter } = {}) {
   const [languageCode, projectCode, dirPath, filename] = splitPootlePath(path);
 
   let url;
@@ -88,8 +88,8 @@ export function getTranslateUrl(path, { check, filter } = {}) {
     return `${url}#filter=${filter}`;
   }
 
-  if (check) {
-    return `${url}#filter=checks&check=${check}`;
+  if (checks) {
+    return `${url}#filter=checks&checks=${checks}`;
   }
 
   return url;

--- a/pootle/static/js/shared/utils/url.js
+++ b/pootle/static/js/shared/utils/url.js
@@ -68,7 +68,7 @@ export function getResourcePath(path) {
  * Retrieves a translation URL out of an internal `path`
  * @param {string} path - internal path
  */
-export function getTranslateUrl(path, { checks, filter } = {}) {
+export function getTranslateUrl(path, { checks, checksCategory, filter } = {}) {
   const [languageCode, projectCode, dirPath, filename] = splitPootlePath(path);
 
   let url;
@@ -90,6 +90,10 @@ export function getTranslateUrl(path, { checks, filter } = {}) {
 
   if (checks) {
     return `${url}#filter=checks&checks=${checks}`;
+  }
+
+  if (checksCategory) {
+    return `${url}#filter=checks&category=${checksCategory}`;
   }
 
   return url;

--- a/pootle/static/js/shared/utils/url.test.js
+++ b/pootle/static/js/shared/utils/url.test.js
@@ -167,4 +167,32 @@ describe('url', () => {
       expect(getTranslateUrl(test.path)).toEqual(test.expected);
     });
   });
+
+  it('constructs translate URLs from internal paths with filters', () => {
+    const tests = [
+      {
+        path: '/ru/',
+        opts: { checks: '', filter: '' },
+        expected: '/ru/translate/',
+      },
+      {
+        path: '/ru/',
+        opts: { checks: '', filter: 'incomplete' },
+        expected: '/ru/translate/#filter=incomplete',
+      },
+      {
+        path: '/ru/',
+        opts: { checks: 'foo', filter: 'incomplete' },
+        expected: '/ru/translate/#filter=incomplete',
+      },
+      {
+        path: '/ru/',
+        opts: { checks: 'linebreaks', filter: '' },
+        expected: '/ru/translate/#filter=checks&checks=linebreaks',
+      },
+    ];
+    tests.forEach((test) => {
+      expect(getTranslateUrl(test.path, test.opts)).toEqual(test.expected);
+    });
+  });
 });

--- a/pootle/static/js/shared/utils/url.test.js
+++ b/pootle/static/js/shared/utils/url.test.js
@@ -190,6 +190,11 @@ describe('url', () => {
         opts: { checks: 'linebreaks', filter: '' },
         expected: '/ru/translate/#filter=checks&checks=linebreaks',
       },
+      {
+        path: '/ru/',
+        opts: { checks: '', checksCategory: 'critical', filter: '' },
+        expected: '/ru/translate/#filter=checks&category=critical',
+      },
     ];
     tests.forEach((test) => {
       expect(getTranslateUrl(test.path, test.opts)).toEqual(test.expected);


### PR DESCRIPTION
* URLs for individual checks were not properly generated
* URLs for check categories can now be generated
* All code now leverages `getTranslateUrl()`