### PR TITLE
Extended gitignore to disregard zing-env folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ node_modules/
 assets/
 _layouts/
 _site/
+
+#Zing-env in local machines
+zing-env

--- a/pootle/log/README
+++ b/pootle/log/README
@@ -1,1 +1,0 @@
-This directory (log) contains the Pootle activity logs.


### PR DESCRIPTION
 (where local dependencies are stored in development machines)