### PR TITLE
Fix evernote#468: Support Plurr preview for simple placeholders

### DIFF
--- a/pootle/static/js/editor/containers/EditorContainer.js
+++ b/pootle/static/js/editor/containers/EditorContainer.js
@@ -70,6 +70,7 @@ const EditorContainer = React.createClass({
   getTextareaComponent() {
     // FIXME: load these on-demand
     const { sourceValues } = this.props;
+    //[0] to extract the only element in the list
     switch (detectFormat(sourceValues[0])) {
       case Formats.PLURR:
         return PlurrEditor;

--- a/pootle/static/js/editor/utils/strings.js
+++ b/pootle/static/js/editor/utils/strings.js
@@ -11,11 +11,13 @@ export const Formats = {
   PLURR: 'PLURR',
 };
 
-/**
- * Returns the string format detected for `value`.
- */
 export function detectFormat(value) {
+  // matches placholders with the form {FOO:xxxxx}
   if (value.search(/{[^{}]*:.*?}/) !== -1) {
+    return Formats.PLURR;
+
+    // matches simple placeholders like {FOO}
+  } else if (value.search(/{[^ ]*}/) !== -1) {
     return Formats.PLURR;
   }
   return Formats.TEXT;


### PR DESCRIPTION
Allows for a wider set of tokens to be handled by Plurr