### PR TITLE
Add descriptions for line break-related checks

### DIFF
--- a/pootle/templates/help/_pootle_quality_checks.html
+++ b/pootle/templates/help/_pootle_quality_checks.html
@@ -1,122 +1,121 @@
 <h3 id="broken_entities">Broken HTML Entities</h3>
-
-<p>The HTML entities must be written as <code>&amp;name;</code>, <code>&amp;#DDDD;</code> or <code>&amp;#xHHHH;</code> (where 'name' is a valid entity name, and 'DDDD' and 'HHHH' are the Unicode symbol numbers in decimal or hexadecimal formats respectively).</p>
-
+<p>The HTML entities must be written as <code>&amp;name;</code>, <code>&amp;#DDDD;</code> or <code>&amp;#xHHHH;</code>
+  (where 'name' is a valid entity name, and 'DDDD' and 'HHHH' are the Unicode symbol numbers in decimal or hexadecimal
+  formats respectively).
+</p>
 <p>Common mistakes:</p>
-
 <ul>
   <li>
-    <code>&amp;nbsp</code> &mdash; this one is missing the trailing semicolon. The correct one will be <code>&amp;nbsp<strong>;</strong></code>.
+    <code>&amp;nbsp</code> &mdash; this one is missing the trailing semicolon. The correct one will be
+    <code>&amp;nbsp<strong>;</strong></code>.
   </li>
   <li>
-    <code>&amp;gt ;</code> &mdash; this one has an extra space between the name and the semicolon. The correct one will be <code>&amp;gt;</code>.
+    <code>&amp;gt ;</code> &mdash; this one has an extra space between the name and the semicolon. The correct one will
+    be <code>&amp;gt;</code>.
   </li>
 </ul>
-
-
 <h3 id="java_format">Java format</h3>
-
-<p>Java format placeholder strings usually look like: <code>{0}</code>, <code>{1,number}</code>, <code>{2,number,#.##}</code>. When you see such placeholders in source strings, please make sure to keep them unmodified in he target ones. You are allowed to change the ordering of multiple placeholders to better suit your translation. For the curious, please see the detailed documentation on <a href="http://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html">Java MessageFormat syntax</a>.</p>
-
+<p>Java format placeholder strings usually look like: <code>{0}</code>, <code>{1,number}</code>,
+  <code>{2,number,#.##}</code>. When you see such placeholders in source strings, please make sure to keep them
+  unmodified in he target ones. You are allowed to change the ordering of multiple placeholders to better suit your
+  translation. For the curious, please see the detailed documentation on <a
+    href="http://docs.oracle.com/javase/7/docs/api/java/text/MessageFormat.html">Java MessageFormat syntax</a>.
+</p>
 <p>Common mistakes:</p>
-
 <ul>
   <li>
     <code>{0 number}</code> &mdash; this one is missing the comma. The correct one will be <code>{0,number}</code>.
   </li>
   <li>
-    <code>{0,numero}</code> &mdash; here the special word <em>number</em> is translated though it shouldn't be. The correct one is <code>{0,number}</code>.
+    <code>{0,numero}</code> &mdash; here the special word <em>number</em> is translated though it shouldn't be. The
+    correct one is <code>{0,number}</code>.
   </li>
 </ul>
-
-
 <h3 id="template_format">Template format</h3>
-
-<p>These are placeholders of the following format: <code>${fullName}</code>, <code>${pendingUserEmail}</code>, <code>${if:accountManagerExists}</code>. When you see such placeholders in source strings, please make sure to keep them unmodified in he target ones. You are allowed to change the ordering of multiple placeholders to better suit your translation.</p>
-
+<p>These are placeholders of the following format: <code>${fullName}</code>, <code>${pendingUserEmail}</code>,
+  <code>${if:accountManagerExists}</code>. When you see such placeholders in source strings, please make sure to keep
+  them unmodified in he target ones. You are allowed to change the ordering of multiple placeholders to better suit your
+  translation.
+</p>
 <p>Common mistakes:</p>
-
 <ul>
   <li>
-    <code>${Nombre completo}</code> &mdash; the text inside the braces is translated, you must leave the original one (<code>${fullName}</code>).
+    <code>${Nombre completo}</code> &mdash; the text inside the braces is translated, you must leave the original one
+    (<code>${fullName}</code>).
   </li>
   <li>
-    <code>${BUSINESSNAME}</code> &mdash; here the case was changed from the original (<code>${businessName}</code>), though it shouldn't. The easiest way is just to copy the English text to the target string.
+    <code>${BUSINESSNAME}</code> &mdash; here the case was changed from the original (<code>${businessName}</code>),
+    though it shouldn't. The easiest way is just to copy the English text to the target string.
   </li>
 </ul>
-
-
 <h3 id="mustache_placeholders">Mustache placeholders</h3>
-
-<p>These are the tags with curly braces like: <code>{% verbatim %}{{{pointsUrl}}}{% endverbatim %}</code>, <code>{% verbatim %}{{originalRecipients}}{% endverbatim %}</code>. Please do not modify the text inside such braces and make sure the number of braces in the target string matches the original one.</p>
-
+<p>These are the tags with curly braces like: <code>{% verbatim %}{{{pointsUrl}}}{% endverbatim %}</code>,
+  <code>{% verbatim %}{{originalRecipients}}{% endverbatim %}</code>. Please do not modify the text inside such braces
+  and make sure the number of braces in the target string matches the original one.
+</p>
 <p>Common mistakes:</p>
-
 <ul>
   <li>
-    <code>{% verbatim %}{{/supportLink}{% endverbatim %}</code> &mdash; this tag is missing the trailing brace. Here is the correct one: <code>{% verbatim %}{{/supportLink}}{% endverbatim %}</code>. You can simply copy these tags to your translation.
+    <code>{% verbatim %}{{/supportLink}{% endverbatim %}</code> &mdash; this tag is missing the trailing brace. Here is
+    the correct one: <code>{% verbatim %}{{/supportLink}}{% endverbatim %}</code>. You can simply copy these tags to
+    your translation.
   </li>
   <li>
-    <code>{% verbatim %}{{# getDarkerFontTag}}{{originalRecipients}}{{/ getDarkerFontTag}}{% endverbatim %}</code> &mdash; here the spaces inside both opening and closing tags are unwanted. The correct string should look like this: <code>{% verbatim %}{{#getDarkerFontTag}}{{originalRecipients}}{{/getDarkerFontTag}}{% endverbatim %}</code>.
+    <code>{% verbatim %}{{# getDarkerFontTag}}{{originalRecipients}}{{/ getDarkerFontTag}}{% endverbatim %}</code>
+    &mdash; here the spaces inside both opening and closing tags are unwanted. The correct string should look like this:
+    <code>{% verbatim %}{{#getDarkerFontTag}}{{originalRecipients}}{{/getDarkerFontTag}}{% endverbatim %}</code>.
   </li>
 </ul>
-
-
 <h3 id="mustache_placeholder_pairs">Mustache placeholder pairs</h3>
-
-<p>These are the tags with curly braces like: <code>{% verbatim %}{{#getStrongTag}}{{{appName}}}{{/getStrongTag}}{% endverbatim %}</code>. Please do not modify the text inside such braces, make sure the number of braces in the target string matches the original one and keep in mind that opening tags like <code>{% verbatim %}{{#tagname}}{% endverbatim %}</code> must precede their closing counterparts, <code>{% verbatim %}{{/tagname}}{% endverbatim %}</code>.</p>
-
+<p>These are the tags with curly braces like:
+  <code>{% verbatim %}{{#getStrongTag}}{{{appName}}}{{/getStrongTag}}{% endverbatim %}</code>. Please do not modify the
+  text inside such braces, make sure the number of braces in the target string matches the original one and keep in mind
+  that opening tags like <code>{% verbatim %}{{#tagname}}{% endverbatim %}</code> must precede their closing
+  counterparts, <code>{% verbatim %}{{/tagname}}{% endverbatim %}</code>.
+</p>
 <p>The easiest way to avoid mistakes is to copy the English text to the target string.</p>
-
-
 <h3 id="mustache_like_placeholder_pairs">Mustache like placeholder pairs</h3>
-
-<p>These are the tags with curly braces like: <code>{% verbatim %}{{getStrongTag}}{{{appName}}}{{/getStrongTag}}{% endverbatim %}</code>. Please do not modify the text inside such braces, make sure the number of braces in the target string matches the original one and keep in mind that opening tags like <code>{% verbatim %}{{tagname}}{% endverbatim %}</code> must precede their closing counterparts, <code>{% verbatim %}{{/tagname}}{% endverbatim %}</code>.</p>
-
+<p>These are the tags with curly braces like:
+  <code>{% verbatim %}{{getStrongTag}}{{{appName}}}{{/getStrongTag}}{% endverbatim %}</code>. Please do not modify the
+  text inside such braces, make sure the number of braces in the target string matches the original one and keep in mind
+  that opening tags like <code>{% verbatim %}{{tagname}}{% endverbatim %}</code> must precede their closing
+  counterparts, <code>{% verbatim %}{{/tagname}}{% endverbatim %}</code>.
+</p>
 <p>The easiest way to avoid mistakes is to copy the English text to the target string.</p>
-
-
 <h3 id="c_format">C format placeholders</h3>
-
 <p>These are placeholders like <code>%s</code>, <code>%d</code>, <code>%.2f</code>, <code>%x</code>.</p>
-
 <p>Such placeholders must not be modified and must be present in translation.</p>
-
-
 <h3 id="non_printable">Non printable</h3>
-
-<p>This check serves to detect internal symbols in the translations. Please make sure you didn't copy anything from the application that can generate the code with such symbols.</p>
-
-
+<p>This check serves to detect internal symbols in the translations. Please make sure you didn't copy anything from the
+  application that can generate the code with such symbols.
+</p>
 <h3 id="unbalanced_tag_braces">Unbalanced tag braces</h3>
-
-<p>Please keep in mind that the number of opening and closing braces in source and target strings should always match. Here are a few common tags: <code>&lt;strong&gt;(&lt;/strong&gt;)</code>, <code>&lt;em&gt;(&lt;/em&gt;)</code>, <code>&lt;span&gt;(&lt;/span&gt;)</code>, etc.</p>
-
+<p>Please keep in mind that the number of opening and closing braces in source and target strings should always match.
+  Here are a few common tags: <code>&lt;strong&gt;(&lt;/strong&gt;)</code>, <code>&lt;em&gt;(&lt;/em&gt;)</code>,
+  <code>&lt;span&gt;(&lt;/span&gt;)</code>, etc.
+</p>
 <p>Common mistakes:</p>
-
 <ul>
   <li>
-    <code>&lt;strong</code> &mdash; this tag is missing the trailing brace. Here is the correct one: <code>&lt;/strong&gt;</code>. You can simply copy these tags to your translation.
+    <code>&lt;strong</code> &mdash; this tag is missing the trailing brace. Here is the correct one:
+    <code>&lt;/strong&gt;</code>. You can simply copy these tags to your translation.
   </li>
   <li>
     <code>&lt;/strong&gt;&lt;/strong&gt;</code> &mdash; an extra tag is added to the target string.
   </li>
 </ul>
-
-
 <h3 id="changed_attributes">Changed attributes</h3>
-
-<p>Please keep in mind that the attributes of the following tags in source and target strings should always match: <code>&lt;span&gt;</code>, <code>&lt;a href&gt;</code>.</p>
-
-
+<p>Please keep in mind that the attributes of the following tags in source and target strings should always match:
+  <code>&lt;span&gt;</code>, <code>&lt;a href&gt;</code>.
+</p>
 <h3 id="unescaped_ampersands">Unescaped ampersands</h3>
-
-<p>All standalone &amp; symbols need to be escaped as <code>&amp;amp;</code> Here are examples of valid use of ampersands in named HTML entities: <code>&amp;quot;</code>, <code>&amp;gt;</code>, <code>&amp;mdash;</code>, etc.</p>
-
-<p>Please avoid either replacing the code that stands for quotation marks (<code>&amp;quot;</code>) or dashes (<code>&amp;mdash;</code>) with the marks themselves (&quot;, &mdash;) or omitting them in your translation.</p>
-
+<p>All standalone &amp; symbols need to be escaped as <code>&amp;amp;</code> Here are examples of valid use of
+  ampersands in named HTML entities: <code>&amp;quot;</code>, <code>&amp;gt;</code>, <code>&amp;mdash;</code>, etc.
+</p>
+<p>Please avoid either replacing the code that stands for quotation marks (<code>&amp;quot;</code>) or dashes
+  (<code>&amp;mdash;</code>) with the marks themselves (&quot;, &mdash;) or omitting them in your translation.
+</p>
 <p>Common mistakes:</p>
-
 <ul>
   <li>
     <code>&</code> &mdash; should be <code>&amp;amp;</code>.
@@ -125,53 +124,49 @@
     <code>Edit &gt; Find &gt; Save Search</code> &mdash; should be <code>Edit &amp;gt; Find &amp;gt; Save Search</code>.
   </li>
 </ul>
-
-
 <h3 id="whitespace">Whitespaces</h3>
-
-<p>This check compares the number of leading and trailing whitespaces and newlines in source and target strings. Make sure the translation has the same number of leading or trailing spaces and/or newlines as the original, otherwise this may result in rendering problems in the UI of our software clients.</p>
-
-
+<p>This check compares the number of leading and trailing whitespaces and newlines in source and target strings. Make
+  sure the translation has the same number of leading or trailing spaces and/or newlines as the original, otherwise this
+  may result in rendering problems in the UI of our software clients.
+</p>
 <h3 id="date_format">Date format</h3>
-
-<p>Checks whether date formats are consistent between the two strings. Here are the examples: <code>MM/yyyy</code>, <code>hh:mm a</code>, <code>EEEE, MMMM d yyyy</code>, etc. Please see <a href="http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html">SimpleFormat documentation</a> for more information, and use this <a href="http://www.fileformat.info/tip/java/simpledateformat.htm">online datetime format validation tool</a> to test your patterns.</p>
-
+<p>Checks whether date formats are consistent between the two strings. Here are the examples: <code>MM/yyyy</code>,
+  <code>hh:mm a</code>, <code>EEEE, MMMM d yyyy</code>, etc. Please see <a
+    href="http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html">SimpleFormat documentation</a> for
+  more information, and use this <a href="http://www.fileformat.info/tip/java/simpledateformat.htm">online datetime
+    format validation tool</a> to test your patterns.
+</p>
 <p>Common mistakes:</p>
-
 <ul>
   <li>
-    <code>MM/aaaa</code> &mdash; the 'year' part is localized here though it should be left in English (<code>MM/yyyy</code>).
+    <code>MM/aaaa</code> &mdash; the 'year' part is localized here though it should be left in English
+    (<code>MM/yyyy</code>).
   </li>
   <li>
     <code>h mm</code> &mdash; this string is missing the colon, the correct is <code>h:mm</code>.
   </li>
 </ul>
-
-<p>You are allowed to change the ordering of multiple parameters to meet your region's standards (e.g. <code>EEEE, dd MMMM yyyy, hh:mm</code>, <code>dd MMMM yyyy, EEEE, hh:mm</code>, <code><code>yyyy MMMM dd, EEEE, hh:mm</code></code>).</p>
-
-
+<p>You are allowed to change the ordering of multiple parameters to meet your region's standards (e.g.
+  <code>EEEE, dd MMMM yyyy, hh:mm</code>, <code>dd MMMM yyyy, EEEE, hh:mm</code>,
+  <code><code>yyyy MMMM dd, EEEE, hh:mm</code></code>).
+</p>
 <h3 id="uppercase_placeholders">Uppercase placeholders</h3>
-
-<p>Checks whether uppercase placeholders are consistent between the two strings. Examples: <code>SYMBOLS_NUMBER</code>, <code>HKEY_CURRENT_USER</code>.</p>
-
+<p>Checks whether uppercase placeholders are consistent between the two strings. Examples: <code>SYMBOLS_NUMBER</code>,
+  <code>HKEY_CURRENT_USER</code>.
+</p>
 <p>Common mistakes:</p>
-
 <ul>
   <li>
-    <code>SIMBOLOS_NUMEROS</code> &mdash; the placeholder is translated though it shouldn't be. The correct one is <code>SYMBOLS_NUMBER</code>.
+    <code>SIMBOLOS_NUMEROS</code> &mdash; the placeholder is translated though it shouldn't be. The correct one is
+    <code>SYMBOLS_NUMBER</code>.
   </li>
   <li>
     <code>symbols_number</code> &mdash; make sure to use upper case.
   </li>
 </ul>
-
-
 <h3 id="percent_sign_placeholders">Percent sign placeholders</h3>
-
 <p>Example: <code>%some_text</code></p>
-
 <p>Common mistakes:</p>
-
 <ul>
   <li>
     <code>%какой-то_текст</code> &mdash; The placeholder is translated or modified though it shouldn't be.
@@ -183,39 +178,28 @@
     <code>% some_text</code> &mdash; A space added between the percent sign and the placeholder.
   </li>
 </ul>
-
-
 <h3 id="percent_sign_closure_placeholders">Percent sign closure placeholders</h3>
-
-<p>Here are some examples of such placeholders: <code>%%Edit%%</code>, <code>%%Notebook%%</code>, <code>%%Taglist%%</code>.</p>
-
+<p>Here are some examples of such placeholders: <code>%%Edit%%</code>, <code>%%Notebook%%</code>,
+  <code>%%Taglist%%</code>.
+</p>
 <p>Common mistakes:</p>
-
 <ul>
   <li>
-    <code>%%Modificat%%</code> &mdash; the placeholder is translated though it shouldn't be. The correct one is <code>%%Edit%%</code>
+    <code>%%Modificat%%</code> &mdash; the placeholder is translated though it shouldn't be. The correct one is
+    <code>%%Edit%%</code>
   </li>
   <li>
-    <code>%%Edit</code> &mdash; this one is missing trailing percent signs. Here is the correct one: <code>%%Edit%%</code>
+    <code>%%Edit</code> &mdash; this one is missing trailing percent signs. Here is the correct one:
+    <code>%%Edit%%</code>
   </li>
 </ul>
-
 <p>Also please make sure the number of percent signs in your translation matches the one in the source string.</p>
-
-
 <h3 id="dollar_sign_placeholders">$ placeholders</h3>
-
 <p>These are the placeholders like <code>$tag</code>, <code>$bar2</code>, <code>$3</code>.</p>
-
 <p>All of these must not be translated and must be present in translation.</p>
-
-
 <h3 id="dollar_sign_closure_placeholders">$ closure placeholders</h3>
-
 <p>Example: <code>$num$</code></p>
-
 <p>Common mistakes:</p>
-
 <ul>
   <li>
     <code>%num%</code> &mdash; Dollar sign is replaced with percent sign.
@@ -230,35 +214,25 @@
     <code>$some_other_text$</code> &mdash; The placeholder is modified.
   </li>
 </ul>
-
-
 <h3 id="javaencoded_unicode">Java-encoded unicode</h3>
-
 <p>Here are a couple of examples: <code>\u2011</code>, <code>\u00AE</code>.</p>
-
 <p>Please make sure to keep such elements unmodified. The easiest way is to copy them from the source string.</p>
-
-
 <h3 id="objective_c_format">Objective-C format</h3>
-
-<p>These are variables of the following format: <code>%@</code>, <code>%1$@</code>, <code>'%1$i'</code>,<code>'%1$i'</code> etc.</p>
-
-<p>Please make sure not to modify such variables in your translations. They should be exactly the same as in the source. Do not replace any characters inside a variable, do not change the quotes format.</p>
-
-
+<p>These are variables of the following format: <code>%@</code>, <code>%1$@</code>,
+  <code>'%1$i'</code>,<code>'%1$i'</code> etc.
+</p>
+<p>Please make sure not to modify such variables in your translations. They should be exactly the same as in the source.
+  Do not replace any characters inside a variable, do not change the quotes format.
+</p>
 <h3 id="android_format">Android format</h3>
-
 <p>These are the placeholders like <code>%1$s</code>, <code>%2$ld</code>.</p>
-
 <p>Here all symbols after $ are special ones and must not be changed.</p>
-
-
 <h3 id="accelerators">Accelerators</h3>
-
-<p>These are words containing ampersands (<code>&amp;</code>) or underscores (<code>&#95;</code>). Ampersands and underscores stand before letter that are used as hot keys on your keyboard that you can press to quickly access a menu or function.</p>
-
+<p>These are words containing ampersands (<code>&amp;</code>) or underscores (<code>&#95;</code>). Ampersands and
+  underscores stand before letter that are used as hot keys on your keyboard that you can press to quickly access a menu
+  or function.
+</p>
 <p>Please do not omit them in your translation. Try to keep it similar to the English, look at the examples below:</p>
-
 <ul>
   <li>
     <code>Note H&istory</code> is <code>Stor&ico della Nota</code> in Italian.
@@ -267,40 +241,34 @@
     <code>View _Tags</code> is <code>Ver E_tiquetas</code> in Portuguese.
   </li>
 </ul>
-
-
 <h3 id="unbalanced_curly_braces">Curly braces</h3>
-
 <p>The number of opening and closing braces (<code>{</code> and <code>}</code>) must match.</p>
-
-
 <h3 id="double_quotes_in_tags">Double quotes in tags</h3>
-
-<p>This check counts the number of double quotation marks (") inside XML/HTML tags (<...>) in source and translated phrases. If the number doesn't match, you'll see the respective error. Check up for missing or unnecessary double quotation marks inside XML/HTML tags in the translated string.</p>
-
+<p>This check counts the number of double quotation marks (") inside XML/HTML tags (<...>) in source and translated
+    phrases. If the number doesn't match, you'll see the respective error. Check up for missing or unnecessary double
+    quotation marks inside XML/HTML tags in the translated string.
+</p>
 <p>Common mistakes:</p>
-
 <ul>
   <li>
-    Missing double quote mark: <code>&lt;a href=http://evernote.com/contact/support/"&gt;</code> - there's a missing double quote mark before <b>http</b>.
+    Missing double quote mark: <code>&lt;a href=http://evernote.com/contact/support/"&gt;</code> - there's a missing
+    double quote mark before <b>http</b>.
   </li>
   <li>
-    Incorrect quote marks format: <code>&lt;a href="http://evernote.com/contact/support/»&gt;</code> - ending double quote mark is not in proper format.
+    Incorrect quote marks format: <code>&lt;a href="http://evernote.com/contact/support/»&gt;</code> - ending double
+    quote mark is not in proper format.
   </li>
 </ul>
-
-
 <h3 id="doublequoting">Doublequoting</h3>
-
-<p>This check compares total amount of double quote marks in the original and translated string. If the number of double quotation marks in source and translation is the same in any part of the string (not just in tags), you'll see the notification. This is a non-critical check.</p>
-
-
+<p>This check compares total amount of double quote marks in the original and translated string. If the number of double
+  quotation marks in source and translation is the same in any part of the string (not just in tags), you'll see the
+  notification. This is a non-critical check.
+</p>
 <h3 id="potential_unwanted_placeholders">Potential unwanted placeholders</h3>
-
-<p>This error is displayed if the translated string contains more symbols &quot;@&quot;, &quot;_&quot;, &quot;$&quot;, or &quot;%&quot; than the source string.</p>
-
+<p>This error is displayed if the translated string contains more symbols &quot;@&quot;, &quot;_&quot;, &quot;$&quot;,
+  or &quot;%&quot; than the source string.
+</p>
 <p>Example:</p>
-
 <ul>
   <li>
     Source text: <code>Quarterly Sales Meeting v5</code>
@@ -309,14 +277,9 @@
     Translated text: <code>Réunion_rapports_trimestriels_ventes v5</code>
   </li>
 </ul>
-
-
 <h3 id="percent_brace_placeholders">Percent brace placeholders</h3>
-
 <p>Example: <code>%{placeholder}</code></p>
-
 <p>Common mistakes:</p>
-
 <ul>
   <li>
     <code>%placeholder</code> &mdash; Braces are missing
@@ -331,46 +294,115 @@
     <code>%{плейсхолдер}</code> &mdash; Placeholder is translated
   </li>
 </ul>
-
-
 <h3 id="tags_differ">Tags differ</h3>
-
-<p>This check compares number of tags in the source string and the translated string, plus the text contained in tags.</p>
-
+<p>This check compares number of tags in the source string and the translated string, plus the text contained in tags.
+</p>
 <p>Example: <code> &lt;font face=&quot;courier&quot; size=+3&gt;Sponsored Group Service Signup&lt;/font&gt;</code>.</p>
-
 <p>Common mistakes:</p>
-
 <ul>
   <li>
     <code>Sponsored Group Service Signup</code> &mdash; Tags are missing
   </li>
   <li>
-    <code>&lt;font =&quot;courier&quot; size=+3&gt;Sponsored Group Service Signup&lt;/font&gt;</code> &mdash;  Text inside tags is modified
+    <code>&lt;font =&quot;courier&quot; size=+3&gt;Sponsored Group Service Signup&lt;/font&gt;</code> &mdash; Text
+    inside tags is modified
   </li>
   <li>
-    <code>font face=&quot;courier&quot; size=+3&gt;Sponsored Group Service Signup&lt;/font</code> &mdash; Angle brackets are missing
+    <code>font face=&quot;courier&quot; size=+3&gt;Sponsored Group Service Signup&lt;/font</code> &mdash; Angle brackets
+    are missing
   </li>
 </ul>
-
-<p>Generally, it's a good idea to copy the source string to translation field and translate it leaving tags not modified.</p>
-
-
+<p>Generally, it's a good idea to copy the source string to translation field and translate it leaving tags not
+  modified.
+</p>
 <h3 id="incorrectly_escaped_ampersands">Incorrectly escaped ampersands</h3>
-
-<p>You'll see this error if ampersand sign from the source string is replaced with corresponding HTML entity in the translation.</p>
-
+<p>You'll see this error if ampersand sign from the source string is replaced with corresponding HTML entity in the
+  translation.
+</p>
 <p>Example: <code> Articles &amp; Guides</code></p>
-
 <p>Common mistake:</p>
-
 <ul>
   <li>
-    <code>Articles &amp;amp; Guides</code> &mdash;  &amp; sign is replaced with &quot;&amp;amp;&quot; in the translated string.
+    <code>Articles &amp;amp; Guides</code> &mdash; &amp; sign is replaced with &quot;&amp;amp;&quot; in the translated
+    string.
   </li>
 </ul>
-
-
 <h3 id="plurr_format">Plurr format</h3>
-
-<p>When using Plurr-formatted strings, this check ensures strings contain no syntax errors. This can typically happen when missing out on closing braces or adding extra braces.</p>
+<p>When using Plurr-formatted strings, this check ensures strings contain no syntax errors. This can typically happen
+  when missing out on closing braces or adding extra braces.
+</p>
+<h3 id="linebreaks_single">Single line breaks</h3>
+<p>Line break checks are implemented in order to deal better with multiline (plaintext) units that can be split into
+  multiple paragraphs.
+</p>
+<ul>
+  <li>
+    <code>Single line breaks</code> &mdash; check counts only single line breaks both in source and target, i.e.
+    <code>LF</code>, and is triggered if counts don't match.
+  </li>
+</ul>
+<p>Example:</p>
+<blockquote>
+  Evernote can help you ␊<br />
+  organize your life.<br />
+  </br>
+</blockquote>
+<p>Common mistake: The number of single line breaks does not match the source.</p>
+<blockquote>
+  Evernote can help you ␊<br />
+  organize your life.␊<br />
+  <br />
+</blockquote>
+<h3 id="linebreaks_double">Double line breaks</h3>
+<p>Line break checks are implemented in order to deal better with multiline (plaintext) units that can be split into
+  multiple paragraphs.
+</p>
+<ul>
+  <li>
+    <code>Double line breaks</code> &mdash; check counts only double line breaks both in source and target, i.e.
+    <code>LF LF</code>, and is triggered if counts don't match.
+  </li>
+</ul>
+<p>Example:</p>
+<blockquote>
+  Evernote can help you ␊<br />
+  organize your life.<br />
+  <br />
+</blockquote>
+<p>Common mistake: The number of double line breaks does not match the source.</p>
+<blockquote>
+  Evernote can help you ␊<br />
+  organize your life.␊<br />
+  ␊<br />
+  <br />
+</blockquote>
+<h3 id="linebreaks_multiple">Multiple line breaks</h3>
+<p>Line break checks are implemented in order to deal better with multiline (plaintext) units that can be split into
+  multiple paragraphs.
+</p>
+<ul>
+  <li>
+    <code>Multiple line breaks</code> &mdash; this check counts instances of only 3 or more subsequent line breaks both
+    in source and target, and is triggered if counts don't match.
+  </li>
+</ul>
+<p>Example:</p>
+<blockquote>
+  Evernote can help you ␊<br />
+  organize your life␊<br />
+  ␊<br />
+  by creating tasks␊<br />
+  and setting reminders.<br />
+  <br />
+</blockquote>
+<p>Common mistake: The number of multiple line breaks does not match the source.</p>
+<blockquote>
+  Evernote can help you ␊<br />
+  organize your life␊<br />
+  ␊<br />
+  by creating tasks␊<br />
+  and setting reminders.␊<br />
+  ␊<br />
+  ␊<br />
+  <br />
+</blockquote>


### PR DESCRIPTION
Example of how it looks:
<img width="1220" alt="image" src="https://user-images.githubusercontent.com/26126311/82093416-126dcc80-96c9-11ea-8a07-fda4d7b0dad5.png">
