### PR TITLE
Fix outdated Zing version number

### DIFF
--- a/pootle/constants.py
+++ b/pootle/constants.py
@@ -7,4 +7,4 @@
 # or later license. See the LICENSE file for a copy of the license and the
 # AUTHORS file for copyright and authorship information.
 
-VERSION = (0, 9, 4, "final", 0)
+VERSION = (0, 9, 7, "final", 0)

--- a/pootle/static/js/package-lock.json
+++ b/pootle/static/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zing",
-  "version": "0.9.4",
+  "version": "0.9.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zing",
-      "version": "0.9.4",
+      "version": "0.9.7",
       "license": "GPL-3.0",
       "dependencies": {
         "autosize": "^3.0.18",

--- a/pootle/static/js/package.json
+++ b/pootle/static/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zing",
-  "version": "0.9.4",
+  "version": "0.9.7",
   "license": "GPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is not a version bump. This is to align the version with the latest git release.