### PR TITLE
Bump python-levenshtein from 0.12.0 to 0.12.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ django-statici18n==1.9.0
 cssmin==0.2.0
 elasticsearch>=7.0.0,<8.0.0
 lxml==4.4.2
-python-levenshtein==0.12.0
+python-levenshtein==0.12.1
 rq==1.2.0
 
 # Translate Toolkit


### PR DESCRIPTION
The following warning is issued during installation:

===
WARNING: The candidate selected for download or install is a yanked version: 'python-levenshtein' candidate (version 0.12.0 at https://files.pythonhosted.org/packages/42/a9/d1785c85ebf9b7dfacd08938dd028209c34a0ea3b1bcdb895208bd40a67d/python-Levenshtein-0.12.0.tar.gz#sha256=033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1 (from https://pypi.org/simple/python-levenshtein/))
Reason for being yanked: Insecure, upgrade to 0.12.1
===

Newer versions (0.21.0) are also available, but I haven't tested bumping up that far yet.